### PR TITLE
Fix center body when title missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v1.1.1
+## Fixed
+- AndesMessage: when title is nil or empty center the body of the message.
+
 # v1.1.0
 - AndesMessage basic
 - AndesMessage dismissible

--- a/Example/AndesUI/Messages/Views/MessageViewController.swift
+++ b/Example/AndesUI/Messages/Views/MessageViewController.swift
@@ -25,7 +25,7 @@ class MessageViewController: UIViewController {
         "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur."
     ]
 
-    let titleDict = ["Title", "Two Words", "One, Two, Three, Four...", "Super long title to see if title can be multiline or not, can it?"]
+    let titleDict = ["", "Title", "Two Words", "One, Two, Three, Four...", "Super long title to see if title can be multiline or not, can it?"]
 
     fileprivate func setupButtons() {
         randomText.setText("Random Description")

--- a/Example/AndesUI/Messages/Views/MessageViewController.xib
+++ b/Example/AndesUI/Messages/Views/MessageViewController.xib
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15702" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
+        <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15704"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -25,13 +27,13 @@
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="7tf-jI-jk9">
-                    <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                    <rect key="frame" x="0.0" y="44" width="414" height="818"/>
                     <subviews>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="GXr-8A-gRp">
                             <rect key="frame" x="0.0" y="0.0" width="414" height="818"/>
                             <subviews>
-                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Headline y bajada" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ZyR-6F-KrR">
-                                    <rect key="frame" x="10" y="119" width="136" height="21"/>
+                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Simple" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ZyR-6F-KrR">
+                                    <rect key="frame" x="10" y="119" width="52" height="21"/>
                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                     <nil key="textColor"/>
                                     <nil key="highlightedColor"/>

--- a/LibraryComponents/Classes/AndesMessage/View/AndesMessageAbstractView.swift
+++ b/LibraryComponents/Classes/AndesMessage/View/AndesMessageAbstractView.swift
@@ -11,6 +11,7 @@ class AndesMessageAbstractView: UIView, AndesMessageView {
     weak var delegate: AndesMessageViewDelegate?
 
     @IBOutlet var messageView: UIView!
+    @IBOutlet weak var titleLabel: UILabel!
     @IBOutlet weak var bodyLabel: UILabel!
     @IBOutlet weak var iconView: UIImageView!
     @IBOutlet weak var iconContainerView: UIView!
@@ -75,6 +76,19 @@ class AndesMessageAbstractView: UIView, AndesMessageView {
         self.iconView.tintColor = config.iconColor
         self.iconView.image = config.icon
         self.iconContainerView.backgroundColor = config.iconBackgroundColor
+
+        self.titleLabel.font = config.titleFont
+        self.titleLabel.textColor = config.textColor
+        self.titleLabel.text = config.titleText
+
+        if config.titleText == nil || config.titleText!.isEmpty {
+            titleLabel.isHidden = true
+        } else {
+            self.titleLabel.font = config.titleFont
+            self.titleLabel.textColor = config.textColor
+            self.titleLabel.text = config.titleText
+            self.titleLabel.isHidden = false
+        }
 
         if config.isDismissable, let dismissIcon = config.dismissIcon {
             self.dismissButton.isHidden = false

--- a/LibraryComponents/Classes/AndesMessage/View/Default/AndesMessageDefaultView.xib
+++ b/LibraryComponents/Classes/AndesMessage/View/Default/AndesMessageDefaultView.xib
@@ -10,40 +10,28 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="AndesMessageDefaultView" customModule="AndesUI" customModuleProvider="target">
             <connections>
-                <outlet property="bodyLabel" destination="Gn7-fq-Vqq" id="luX-Kf-sxG"/>
+                <outlet property="bodyLabel" destination="Ka6-MC-Ijq" id="8av-3w-jlS"/>
                 <outlet property="dismissButton" destination="xSe-Le-1pW" id="cYn-eo-qgB"/>
                 <outlet property="iconContainerView" destination="CsU-Ah-Mc0" id="Jga-UN-maA"/>
                 <outlet property="iconView" destination="osp-E1-bQZ" id="EDe-uX-9p8"/>
                 <outlet property="leftPipeView" destination="gFh-wa-OID" id="Cm2-9Z-0LD"/>
                 <outlet property="messageView" destination="iN0-l3-epB" id="GeK-wd-BOU"/>
-                <outlet property="titleLabel" destination="uzt-fN-Gxk" id="Mue-vy-fws"/>
+                <outlet property="titleLabel" destination="pmK-XL-3ub" id="rbc-sb-4AU"/>
             </connections>
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <view contentMode="scaleToFill" id="iN0-l3-epB">
-            <rect key="frame" x="0.0" y="0.0" width="410" height="115"/>
+            <rect key="frame" x="0.0" y="0.0" width="431" height="167"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Lorem ipsum dolor sit amet, consectetur adipiscing elit" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Gn7-fq-Vqq">
-                    <rect key="frame" x="48" y="58" width="313.5" height="41"/>
-                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                    <nil key="textColor"/>
-                    <nil key="highlightedColor"/>
-                </label>
                 <view clipsSubviews="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="gFh-wa-OID">
-                    <rect key="frame" x="0.0" y="0.0" width="5" height="115"/>
+                    <rect key="frame" x="0.0" y="0.0" width="5" height="167"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="5" id="HVg-ad-7cr"/>
                     </constraints>
                 </view>
-                <label opaque="NO" userInteractionEnabled="NO" contentMode="top" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="uzt-fN-Gxk">
-                    <rect key="frame" x="48" y="15" width="313.5" height="38"/>
-                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                    <nil key="textColor"/>
-                    <nil key="highlightedColor"/>
-                </label>
                 <button opaque="NO" contentMode="scaleAspectFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="xSe-Le-1pW">
-                    <rect key="frame" x="378" y="16" width="16" height="16"/>
+                    <rect key="frame" x="399" y="16" width="16" height="16"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="16" id="2KI-xl-eP3"/>
                         <constraint firstAttribute="height" constant="16" id="MJq-Lg-Jjn"/>
@@ -82,27 +70,41 @@
                         </userDefinedRuntimeAttribute>
                     </userDefinedRuntimeAttributes>
                 </view>
+                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="G79-j7-hX6">
+                    <rect key="frame" x="48" y="15.5" width="335" height="135.5"/>
+                    <subviews>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pmK-XL-3ub">
+                            <rect key="frame" x="0.0" y="0.0" width="335" height="20.5"/>
+                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                            <nil key="textColor"/>
+                            <nil key="highlightedColor"/>
+                        </label>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="249" text="body" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ka6-MC-Ijq">
+                            <rect key="frame" x="0.0" y="25.5" width="335" height="110"/>
+                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                            <nil key="textColor"/>
+                            <nil key="highlightedColor"/>
+                        </label>
+                    </subviews>
+                </stackView>
             </subviews>
             <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
             <constraints>
                 <constraint firstItem="xSe-Le-1pW" firstAttribute="centerY" secondItem="CsU-Ah-Mc0" secondAttribute="centerY" id="0D2-0Z-dFM"/>
-                <constraint firstItem="uzt-fN-Gxk" firstAttribute="leading" secondItem="CsU-Ah-Mc0" secondAttribute="trailing" constant="16" id="0lT-dg-NTe"/>
+                <constraint firstItem="xSe-Le-1pW" firstAttribute="leading" secondItem="G79-j7-hX6" secondAttribute="trailing" constant="16" id="ADR-ST-j0L"/>
                 <constraint firstItem="CsU-Ah-Mc0" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" constant="16" id="DgW-9N-a1l"/>
-                <constraint firstItem="Gn7-fq-Vqq" firstAttribute="leading" secondItem="uzt-fN-Gxk" secondAttribute="leading" id="LG0-o8-heM"/>
                 <constraint firstItem="gFh-wa-OID" firstAttribute="bottom" secondItem="iN0-l3-epB" secondAttribute="bottom" id="MIA-Fj-KqH"/>
-                <constraint firstAttribute="bottom" secondItem="Gn7-fq-Vqq" secondAttribute="bottom" constant="16" id="NDS-pf-T4H"/>
-                <constraint firstItem="uzt-fN-Gxk" firstAttribute="top" secondItem="CsU-Ah-Mc0" secondAttribute="top" constant="-1" id="QSB-55-D1M"/>
-                <constraint firstItem="Gn7-fq-Vqq" firstAttribute="trailing" secondItem="uzt-fN-Gxk" secondAttribute="trailing" id="XGc-1k-5vB"/>
                 <constraint firstItem="gFh-wa-OID" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" id="Yn0-Ay-Dnb"/>
                 <constraint firstAttribute="trailing" secondItem="xSe-Le-1pW" secondAttribute="trailing" constant="16" id="ggj-3b-gGj"/>
-                <constraint firstItem="Gn7-fq-Vqq" firstAttribute="top" secondItem="uzt-fN-Gxk" secondAttribute="bottom" constant="5" id="j8X-Y4-kXX"/>
+                <constraint firstItem="G79-j7-hX6" firstAttribute="top" secondItem="osp-E1-bQZ" secondAttribute="top" constant="-1" id="kp4-QZ-7Qj"/>
                 <constraint firstItem="gFh-wa-OID" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="lct-6K-zXa"/>
+                <constraint firstAttribute="bottom" secondItem="G79-j7-hX6" secondAttribute="bottom" constant="16" id="lna-wW-xZh"/>
+                <constraint firstItem="G79-j7-hX6" firstAttribute="leading" secondItem="CsU-Ah-Mc0" secondAttribute="trailing" constant="16" id="oaz-gF-rYB"/>
                 <constraint firstItem="CsU-Ah-Mc0" firstAttribute="leading" secondItem="0RB-UD-MjC" secondAttribute="leading" constant="16" id="osA-ar-bIM"/>
-                <constraint firstItem="xSe-Le-1pW" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="uzt-fN-Gxk" secondAttribute="trailing" constant="16" id="p7u-9g-Imn"/>
             </constraints>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
             <viewLayoutGuide key="safeArea" id="0RB-UD-MjC"/>
-            <point key="canvasLocation" x="137.68115942028987" y="-148.32589285714286"/>
+            <point key="canvasLocation" x="152.89855072463769" y="-130.91517857142856"/>
         </view>
     </objects>
     <resources>

--- a/LibraryComponents/Classes/AndesMessage/View/Default/AndesMessageViewDefault.swift
+++ b/LibraryComponents/Classes/AndesMessage/View/Default/AndesMessageViewDefault.swift
@@ -8,17 +8,8 @@
 import Foundation
 
 class AndesMessageDefaultView: AndesMessageAbstractView {
-    @IBOutlet weak var titleLabel: UILabel!
-
     override func loadNib() {
         let bundle = AndesBundle.bundle()
         bundle.loadNibNamed("AndesMessageDefaultView", owner: self, options: nil)
-    }
-
-    override func updateView() {
-        super.updateView()
-        titleLabel.font = config.titleFont
-        titleLabel.textColor = config.textColor
-        titleLabel.text = config.titleText
     }
 }


### PR DESCRIPTION

## Description
Centers body of AndesMessage when no title is provided.

## Screenshots
![Screen Shot 2020-01-27 at 17 59 19](https://user-images.githubusercontent.com/57450033/73213350-ca816480-412e-11ea-873a-85d5a34e32bf.png)
![Screen Shot 2020-01-27 at 17 59 29](https://user-images.githubusercontent.com/57450033/73213357-ce14eb80-412e-11ea-9fe2-9d908c154153.png)

## Checks
Are you sure you followed all those steps? If so, repeat after me "I solemnly swear that ...":
   - [x] I have coded an example inside the Demo App,
   - [ ] I have added proper tests,
   - [x] I have modified the Changelog.md file,
   - [x] I have updated GitHub wiki,
   - [x] I have the explicit approval of one or more members of the UX Team,
   - [x] I have checked that this code is ObjC compliant.
## Change type
This is easy, let us know what this code is about:
   - [ ] This code adds a new component
   - [x] This code includes improvements to an existent component
   - [ ] This code improves or modifies ONLY the Demo App.