### PR TITLE
Add test for message without title, allow titles nil

### DIFF
--- a/Example/Tests/AndesMessageTests.swift
+++ b/Example/Tests/AndesMessageTests.swift
@@ -95,6 +95,29 @@ class AndesMessageTests: QuickSpec {
                       //Then
                       expect((message.view as! AndesMessageDefaultView).bodyLabel.text).to(match(descToChange))
                   }
+                it("when title is empty or nil, title is hidden") {
+                    //Given
+                    let message = AndesMessage(frame: .zero)
+                    let messageEmpty = AndesMessage(frame: .zero)
+
+                    //When
+                    message.setTitle(nil)
+                    messageEmpty.setTitle("")
+
+                    //Then
+                    expect((message.view as! AndesMessageDefaultView).titleLabel.isHidden).to(beTrue())
+                    expect((messageEmpty.view as! AndesMessageDefaultView).titleLabel.isHidden).to(beTrue())
+                }
+                it("when title is not empty, title label is not hidden") {
+                       //Given
+                       let message = AndesMessage(frame: .zero)
+
+                       //When
+                       message.setTitle("title")
+
+                       //Then
+                       expect((message.view as! AndesMessageDefaultView).titleLabel.isHidden).to(beFalse())
+                   }
             }
         }
         describe("AndesMessage should trigger callbacks on specific events") {

--- a/LibraryComponents/Classes/AndesMessage/AndesMessage.swift
+++ b/LibraryComponents/Classes/AndesMessage/AndesMessage.swift
@@ -68,7 +68,7 @@ import UIKit
 
     /// Sets the title of the AndesMessage
     /// - Parameter title: string
-    @objc @discardableResult public func setTitle(_ title: String) -> AndesMessage {
+    @objc @discardableResult public func setTitle(_ title: String?) -> AndesMessage {
         self.title = title
         updateContentView()
         return self


### PR DESCRIPTION
## Description
Adds tests for AndesMessage without tilte, also allows nil messages to be set with setTitle, THIS IS A NON BREAKING CHANGE because 1) setTitle is not open (so it couldn't have been overwritten, and any previous call to setTitle with non nullable string will still work fine.

## Affected component
AndesMessage
## Checks
Are you sure you followed all those steps? If so, repeat after me "I solemnly swear that ...":
   - [ ] I have coded an example inside the Demo App,
   - [x] I have added proper tests,
   - [ ] I have modified the Changelog.md file,
   - [ ] I have updated GitHub wiki,
   - [ ] I have the explicit approval of one or more members of the UX Team,
   - [ ] I have checked that this code is ObjC compliant.
## Change type
This is easy, let us know what this code is about:
   - [ ] This code adds a new component
   - [x] This code includes improvements to an existent component
   - [ ] This code improves or modifies ONLY the Demo App.