### PR TITLE
andes button open getters, change highlight to neutral

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v1.2.0 (Sin Publicar)
+## Changed
+- AndesButton now exposes getters for properties
+- AndesMessageHierarchy changed highlight to neutral
+
 # v1.1.1
 ## Fixed
 - AndesMessage: when title is nil or empty center the body of the message.

--- a/Example/AndesUI/Messages/Views/MessageObjCViewController.m
+++ b/Example/AndesUI/Messages/Views/MessageObjCViewController.m
@@ -12,7 +12,7 @@
 #import <AndesUI-Swift.h>
 
 @interface MessageObjCViewController ()
-@property (weak, nonatomic) IBOutlet AndesMessage *highlightQuiet;
+@property (weak, nonatomic) IBOutlet AndesMessage *neutralQuiet;
 @property (weak, nonatomic) IBOutlet AndesMessage *errorLoud;
 @property (weak, nonatomic) IBOutlet AndesMessage *successQuiet;
 
@@ -32,13 +32,13 @@
 }
 
 - (void)setupTexts {
-    [[self.highlightQuiet setTitle:@"Highlight"] setBody:@"This is a quiet/highlight message"];
+    [[self.neutralQuiet setTitle:@"Neutral"] setBody:@"This is a quiet/neutral message"];
     [[self.errorLoud setTitle:@"Error"] setBody:@"This is a loud/error message"];
     [[self.successQuiet setTitle:@"Success"] setBody:@"This is a quiet/success message"];
 }
 
 - (void)setupStyles {
-    [self.highlightQuiet setHierarchy:AndesMessageHierarchyLoud];
+    [self.neutralQuiet setHierarchy:AndesMessageHierarchyLoud];
     [self.errorLoud setType:AndesMessageTypeError];
     [[self.successQuiet setType:AndesMessageTypeSuccess] setHierarchy:AndesMessageHierarchyQuiet];
 }

--- a/Example/AndesUI/Messages/Views/MessageObjCViewController.xib
+++ b/Example/AndesUI/Messages/Views/MessageObjCViewController.xib
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15702" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
-    <device id="retina6_1" orientation="portrait" appearance="light"/>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15704"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -11,7 +13,7 @@
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="MessageObjCViewController">
             <connections>
                 <outlet property="errorLoud" destination="y4S-Od-ixo" id="96V-wp-d4f"/>
-                <outlet property="highlightQuiet" destination="TpJ-th-G1p" id="3UO-k2-uNz"/>
+                <outlet property="neutralQuiet" destination="TpJ-th-G1p" id="3UO-k2-uNz"/>
                 <outlet property="successQuiet" destination="d7f-aq-5EC" id="0JS-S4-pNL"/>
                 <outlet property="view" destination="iN0-l3-epB" id="CRr-Mr-d8J"/>
             </connections>
@@ -23,15 +25,15 @@
             <subviews>
                 <view contentMode="scaleToFill" placeholderIntrinsicWidth="384" placeholderIntrinsicHeight="128" translatesAutoresizingMaskIntoConstraints="NO" id="TpJ-th-G1p" customClass="AndesMessage" customModule="AndesUI">
                     <rect key="frame" x="15" y="59" width="384" height="128"/>
-                    <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                    <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                 </view>
                 <view contentMode="scaleToFill" placeholderIntrinsicWidth="384" placeholderIntrinsicHeight="128" translatesAutoresizingMaskIntoConstraints="NO" id="y4S-Od-ixo" customClass="AndesMessage" customModule="AndesUI">
                     <rect key="frame" x="15" y="202" width="384" height="128"/>
-                    <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                    <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                 </view>
                 <view contentMode="scaleToFill" placeholderIntrinsicWidth="384" placeholderIntrinsicHeight="128" translatesAutoresizingMaskIntoConstraints="NO" id="d7f-aq-5EC" customClass="AndesMessage" customModule="AndesUI">
                     <rect key="frame" x="15" y="345" width="384" height="128"/>
-                    <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                    <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                 </view>
             </subviews>
             <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>

--- a/Example/AndesUI/Messages/Views/MessageViewController.swift
+++ b/Example/AndesUI/Messages/Views/MessageViewController.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2020 MercadoLibre. All rights reserved.
 //
 
-import UIKit
+import Foundation
 import AndesUI
 class MessageViewController: UIViewController {
     @IBOutlet weak var contentView: UIView!
@@ -140,8 +140,8 @@ extension MessageViewController: UIPickerViewDataSource {
 extension AndesMessageType {
     func toString() -> String {
         switch self {
-        case .highlight:
-            return "Highlight"
+        case .neutral:
+            return "Neutral"
         case .success:
             return "Success"
         case .error:

--- a/Example/Tests/AndesMessageTests.swift
+++ b/Example/Tests/AndesMessageTests.swift
@@ -14,10 +14,10 @@ class AndesMessageTests: QuickSpec {
     override func spec() {
         describe("AndesMessage should draw its view depending on type, type, and variation") {
             context("AndesMessage dismissable with title and description inits") {
-                it("Andes message by default should be highlight, loud and of defaultView") {
+                it("Andes message by default should be neutral, loud and of defaultView") {
                     //Given
                     let defaultHierarchy = AndesMessageHierarchy.loud
-                    let defaultType = AndesMessageType.highlight
+                    let defaultType = AndesMessageType.neutral
 
                     //When
                     let message = AndesMessage(frame: .zero)

--- a/LibraryComponents/Classes/AndesButton/AndesButton.swift
+++ b/LibraryComponents/Classes/AndesButton/AndesButton.swift
@@ -27,17 +27,24 @@ import UIKit
   The responsibility of the AndesButton is to know how it should be represent based on the attributes provided
  */
 @objc public class AndesButton: UIControl {
+    /// returns the current selected hierarchy
+    public private(set) var hierarchy: AndesButtonHierarchy
 
-    private var hierarchy: AndesButtonHierarchy
-    private var size: AndesButtonSize
+    /// returns the current selected size
+    public private(set) var size: AndesButtonSize
+
+    /// returns the current text
+    public private(set) var text: String
+
+    /// returns the current selected hierarchy
+    public private(set) var icon: AndesButtonIcon?
+
     internal var view: AndesButtonView
-    private var text: String
-    private var icon: AndesButtonIcon?
     private var config: AndesButtonViewConfig
 
     override public var isEnabled: Bool {
         didSet {
-            if (!isEnabled) {
+            if !isEnabled {
                 view.disable()
             } else {
                 view.enable()
@@ -132,9 +139,10 @@ import UIKit
      Allows to change the text content of the button
      - Parameter title: is text that the button will contain
      */
-    @objc public func setText(_ text: String) {
+    @objc @discardableResult public func setText(_ text: String) -> AndesButton {
         self.text = text
         view.setText(text)
+        return self
     }
 
     /**
@@ -143,10 +151,11 @@ import UIKit
     - Parameters:
        - icon the icon with its respective orientation
     */
-    @objc public func setLargeSizeWithIcon(_ icon: AndesButtonIcon) {
+    @objc @discardableResult public func setLargeSizeWithIcon(_ icon: AndesButtonIcon) -> AndesButton {
         self.size = .large
         self.icon = icon
         update()
+        return self
     }
 
     /**
@@ -158,10 +167,11 @@ import UIKit
      - Parameters:
         - sizeStyle is the new size of the button
      */
-    @objc public func setSize(_ size: AndesButtonSize) {
+    @objc @discardableResult public func setSize(_ size: AndesButtonSize) -> AndesButton {
         self.icon = nil
         self.size = size
         update()
+        return self
     }
 
     /**
@@ -172,9 +182,10 @@ import UIKit
      
      - Parameter style: is the new style of the button
      */
-    @objc public func setHierarchy(_ hierarchy: AndesButtonHierarchy) {
+    @objc @discardableResult public func setHierarchy(_ hierarchy: AndesButtonHierarchy) -> AndesButton {
         self.hierarchy = hierarchy
         update()
+        return self
     }
 
     /**

--- a/LibraryComponents/Classes/AndesMessage/AndesMessage.swift
+++ b/LibraryComponents/Classes/AndesMessage/AndesMessage.swift
@@ -13,7 +13,7 @@ import UIKit
     public private(set) var hierarchy: AndesMessageHierarchy = .loud
 
     /// returns the current type
-    public private(set) var type: AndesMessageType = .highlight
+    public private(set) var type: AndesMessageType = .neutral
 
     /// returns the current title
     public private(set) var title: String?

--- a/LibraryComponents/Classes/AndesMessage/Type/AndesMessageType.swift
+++ b/LibraryComponents/Classes/AndesMessage/Type/AndesMessageType.swift
@@ -9,7 +9,7 @@ import Foundation
 
 /// Used to define the colors of an AndesMessage
 @objc public enum AndesMessageType: Int {
-    case highlight
+    case neutral
     case success
     case warning
     case error

--- a/LibraryComponents/Classes/AndesMessage/Type/AndesMessageTypeFactory.swift
+++ b/LibraryComponents/Classes/AndesMessage/Type/AndesMessageTypeFactory.swift
@@ -9,7 +9,7 @@ import Foundation
 class AndesMessageTypeFactory {
     static func provide(_ type: AndesMessageType) -> AndesMessageTypeProtocol {
         switch type {
-        case .highlight:
+        case .neutral:
             return AndesMessageTypeHightlight()
         case .warning:
             return AndesMessageTypeWarning()


### PR DESCRIPTION
## Description
Early adopters asked for public getters on button properties,
And also to match naming for AndesMessage hierarchy with front end
## Checks
Are you sure you followed all those steps? If so, repeat after me "I solemnly swear that ...":
   - [ ] I have coded an example inside the Demo App,
   - [ ] I have added proper tests,
   - [ ] I have modified the Changelog.md file,
   - [ ] I have updated GitHub wiki,
   - [ ] I have the explicit approval of one or more members of the UX Team,
   - [ ] I have checked that this code is ObjC compliant.
## Change type
This is easy, let us know what this code is about:
   - [ ] This code adds a new component
   - [x] This code includes improvements to an existent component
   - [ ] This code improves or modifies ONLY the Demo App.