### PR TITLE
Fix/background message quiet

### DIFF
--- a/AndesUI.podspec
+++ b/AndesUI.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'AndesUI'
-  s.version          = '1.2.1'
+  s.version          = '1.3.0'
   s.summary          = 'AndesUI library for ios app.'
 
   s.description      = 'AndesUI is the UI library of Mercado Libre. It provides the definitions, components and tools to build consistent experiences, with agility and visual quality.'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v1.3.1:
+## Changed
+- AndesMessage: fixed background quiet color.
+
 # v1.3.0
 ## Added
 - AndesMessage: Support message with actions, primary and secondary.

--- a/Example/AndesUI.xcodeproj/project.pbxproj
+++ b/Example/AndesUI.xcodeproj/project.pbxproj
@@ -492,10 +492,12 @@
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-AndesUI-demoapp/Pods-AndesUI-demoapp-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/AndesUI/AndesUI.framework",
+				"${BUILT_PRODUCTS_DIR}/IQKeyboardManagerSwift/IQKeyboardManagerSwift.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/AndesUI.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/IQKeyboardManagerSwift.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/Example/AndesUI/AndesUI-Info.plist
+++ b/Example/AndesUI/AndesUI-Info.plist
@@ -17,11 +17,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.0</string>
+	<string>1.3.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1.0.0.0</string>
+	<string>1.3.0.0</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>

--- a/LibraryComponents/Classes/AndesMessage/Hierarchy/AndesMessageHierarchyQuiet.swift
+++ b/LibraryComponents/Classes/AndesMessage/Hierarchy/AndesMessageHierarchyQuiet.swift
@@ -15,7 +15,7 @@ struct AndesMessageHierarchyQuiet: AndesMessageHierarchyProtocol {
 
     var textColor: UIColor = AndesStyleSheetManager.styleSheet.textPrimaryColor
 
-    var backgroundColor: UIColor = AndesStyleSheetManager.styleSheet.backgroundPrimaryColor
+    var backgroundColor: UIColor = UIColor.AndesColor.Gray.gray40
 
     var pipeColor: UIColor
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,15 +1,18 @@
 PODS:
   - AndesUI (1.2.1)
+  - IQKeyboardManagerSwift (6.3.0)
   - Nimble (7.3.4)
   - Quick (1.2.0)
 
 DEPENDENCIES:
   - AndesUI (from `./`)
+  - IQKeyboardManagerSwift (= 6.3.0)
   - Nimble (~> 7.3.0)
   - Quick (~> 1.2.0)
 
 SPEC REPOS:
   https://github.com/CocoaPods/Specs.git:
+    - IQKeyboardManagerSwift
     - Nimble
     - Quick
 
@@ -19,9 +22,10 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   AndesUI: 65201939c9c095c15810f14c01f944a8db7a6747
+  IQKeyboardManagerSwift: a8228c257614af98743b4cd8584637025f36358f
   Nimble: 051e3d8912d40138fa5591c78594f95fb172af37
   Quick: 58d203b1c5e27fff7229c4c1ae445ad7069a7a08
 
-PODFILE CHECKSUM: 75503ab30bc645e988b37dbdff72eb2e5c78f4bc
+PODFILE CHECKSUM: cff98d0928292cc9e9e8332672703d9b5d5ef222
 
 COCOAPODS: 1.8.4


### PR DESCRIPTION
## Description
Fixing wrong color on AndesMessage Quiet 
## Affected component
AndesMessage

## Screenshots
Before: 
![Screen Shot 2020-02-12 at 17 39 20](https://user-images.githubusercontent.com/57450033/74375176-a3799280-4dbe-11ea-8567-6a5d4b03843d.png)

After
![Screen Shot 2020-02-12 at 17 38 11](https://user-images.githubusercontent.com/57450033/74375173-a1afcf00-4dbe-11ea-88a0-1f53bb76c17c.png)

## Checks
Are you sure you followed all those steps? If so, repeat after me "I solemnly swear that ...":
   - [ ] I have coded an example inside the Demo App,
   - [ ] I have added proper tests,
   - [x] I have modified the Changelog.md file,
   - [ ] I have updated GitHub wiki,
   - [ ] I have the explicit approval of one or more members of the UX Team,
   - [ ] I have checked that this code is ObjC compliant.
## Change type
This is easy, let us know what this code is about:
   - [ ] This code adds a new component
   - [x] This code includes improvements to an existent component
   - [ ] This code improves or modifies ONLY the Demo App.