### PR TITLE
Message fixes constraints, demo app fix

### DIFF
--- a/AndesUI.podspec
+++ b/AndesUI.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'AndesUI'
-  s.version          = '1.3.0'
+  s.version          = '1.3.1'
   s.summary          = 'AndesUI library for ios app.'
 
   s.description      = 'AndesUI is the UI library of Mercado Libre. It provides the definitions, components and tools to build consistent experiences, with agility and visual quality.'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Sin Publicar
+- AndesMessage: fixes in constraints when dismiss is hidden
+
 # v1.3.1:
 ## Changed
 - AndesMessage: fixed background quiet color.

--- a/Example/AndesUI/AndesUI-Info.plist
+++ b/Example/AndesUI/AndesUI-Info.plist
@@ -17,11 +17,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.3.0</string>
+	<string>1.3.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1.3.0.0</string>
+	<string>1.3.1.0</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>

--- a/Example/AndesUI/Messages/Views/MessageViewController.swift
+++ b/Example/AndesUI/Messages/Views/MessageViewController.swift
@@ -61,6 +61,9 @@ class MessageViewController: UIViewController, MessageView {
     fileprivate func setupBaseMessage() {
         messageView.setTitle("message.default.title".localized)
             .setBody("message.default.body".localized)
+            .onDismiss({[unowned self] _ in
+                self.showAgainBtn.isHidden = false
+            })
         messageView.setPrimaryAction("Primary", handler: {[unowned self] _ in self.didPressButton()})
         messageView.setSecondaryAction("Secondary", handler: {[unowned self] _ in self.didPressButton()})
     }
@@ -129,6 +132,7 @@ class MessageViewController: UIViewController, MessageView {
 
     @IBAction func showMsg(_ sender: Any) {
         messageView.isHidden = false
+        showAgainBtn.isHidden = true
     }
 
     @IBAction func updateTapped(_ sender: Any) {

--- a/Example/AndesUI/Messages/Views/MessageViewController.xib
+++ b/Example/AndesUI/Messages/Views/MessageViewController.xib
@@ -48,7 +48,7 @@
                                         <action selector="showConfigTapped:" destination="-1" eventType="touchUpInside" id="nYE-LF-pLc"/>
                                     </connections>
                                 </view>
-                                <view contentMode="scaleToFill" placeholderIntrinsicWidth="48" placeholderIntrinsicHeight="40" translatesAutoresizingMaskIntoConstraints="NO" id="IRM-Ra-dda" customClass="AndesButton" customModule="AndesUI">
+                                <view hidden="YES" contentMode="scaleToFill" placeholderIntrinsicWidth="48" placeholderIntrinsicHeight="40" translatesAutoresizingMaskIntoConstraints="NO" id="IRM-Ra-dda" customClass="AndesButton" customModule="AndesUI">
                                     <rect key="frame" x="16" y="60" width="382" height="40"/>
                                     <color key="backgroundColor" red="0.20392156859999999" green="0.78039215689999997" blue="0.34901960780000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                     <connections>

--- a/LibraryComponents/Classes/AndesMessage/View/AndesMessageAbstractView.swift
+++ b/LibraryComponents/Classes/AndesMessage/View/AndesMessageAbstractView.swift
@@ -17,6 +17,8 @@ class AndesMessageAbstractView: UIView, AndesMessageView {
     @IBOutlet weak var iconContainerView: UIView!
     @IBOutlet weak var leftPipeView: UIView!
     @IBOutlet weak var dismissButton: UIButton!
+    @IBOutlet weak var titleToDismissConstraint: NSLayoutConstraint!
+    @IBOutlet weak var titleToSafeAreaConstraint: NSLayoutConstraint!
 
     var config: AndesMessageViewConfig
     init(withConfig config: AndesMessageViewConfig) {
@@ -92,9 +94,13 @@ class AndesMessageAbstractView: UIView, AndesMessageView {
 
         if config.isDismissable, let dismissIcon = config.dismissIcon {
             self.dismissButton.isHidden = false
+            self.titleToDismissConstraint.priority = .defaultHigh
+            self.titleToSafeAreaConstraint.priority = .defaultLow
             self.dismissButton.tintColor = config.dismissIconColor
             self.dismissButton.setImage(dismissIcon, for: .normal)
         } else {
+            self.titleToDismissConstraint.priority = .defaultLow
+            self.titleToSafeAreaConstraint.priority = .defaultHigh
             self.dismissButton.isHidden = true
         }
     }

--- a/LibraryComponents/Classes/AndesMessage/View/Default/AndesMessageDefaultView.xib
+++ b/LibraryComponents/Classes/AndesMessage/View/Default/AndesMessageDefaultView.xib
@@ -19,6 +19,8 @@
                 <outlet property="leftPipeView" destination="gFh-wa-OID" id="Cm2-9Z-0LD"/>
                 <outlet property="messageView" destination="iN0-l3-epB" id="GeK-wd-BOU"/>
                 <outlet property="titleLabel" destination="pmK-XL-3ub" id="rbc-sb-4AU"/>
+                <outlet property="titleToDismissConstraint" destination="ADR-ST-j0L" id="bph-Hn-aUV"/>
+                <outlet property="titleToSafeAreaConstraint" destination="EcX-Aa-dXv" id="MCy-Ng-wxb"/>
             </connections>
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
@@ -90,8 +92,9 @@
             <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
             <constraints>
                 <constraint firstItem="xSe-Le-1pW" firstAttribute="centerY" secondItem="CsU-Ah-Mc0" secondAttribute="centerY" id="0D2-0Z-dFM"/>
-                <constraint firstItem="xSe-Le-1pW" firstAttribute="leading" secondItem="G79-j7-hX6" secondAttribute="trailing" constant="16" id="ADR-ST-j0L"/>
+                <constraint firstItem="xSe-Le-1pW" firstAttribute="leading" secondItem="G79-j7-hX6" secondAttribute="trailing" priority="999" constant="16" id="ADR-ST-j0L"/>
                 <constraint firstItem="CsU-Ah-Mc0" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" constant="16" id="DgW-9N-a1l"/>
+                <constraint firstAttribute="trailing" secondItem="G79-j7-hX6" secondAttribute="trailing" priority="250" constant="32" id="EcX-Aa-dXv"/>
                 <constraint firstItem="gFh-wa-OID" firstAttribute="bottom" secondItem="iN0-l3-epB" secondAttribute="bottom" id="MIA-Fj-KqH"/>
                 <constraint firstItem="gFh-wa-OID" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" id="Yn0-Ay-Dnb"/>
                 <constraint firstAttribute="trailing" secondItem="xSe-Le-1pW" secondAttribute="trailing" constant="16" id="ggj-3b-gGj"/>

--- a/LibraryComponents/Classes/AndesMessage/View/WithActions/AndesMessageWithActionsView.xib
+++ b/LibraryComponents/Classes/AndesMessage/View/WithActions/AndesMessageWithActionsView.xib
@@ -21,6 +21,8 @@
                 <outlet property="primaryAction" destination="HbG-CF-Oqd" id="RZJ-M4-73O"/>
                 <outlet property="secondaryAction" destination="UDP-xQ-Pdx" id="ob2-GU-6z7"/>
                 <outlet property="titleLabel" destination="KcW-WK-QzY" id="pau-ca-pFK"/>
+                <outlet property="titleToDismissConstraint" destination="ndm-ak-doY" id="DG1-v9-dga"/>
+                <outlet property="titleToSafeAreaConstraint" destination="JEr-pg-mxz" id="ubT-XX-3F2"/>
             </connections>
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
@@ -111,12 +113,13 @@
                 <constraint firstItem="Mbf-ep-nbj" firstAttribute="leading" secondItem="Cit-nC-uGc" secondAttribute="leading" constant="16" id="DMY-o7-nfT"/>
                 <constraint firstItem="kN4-J7-3O6" firstAttribute="top" secondItem="XXP-Ea-Yt4" secondAttribute="top" id="EX0-Ps-HuH"/>
                 <constraint firstItem="UDP-xQ-Pdx" firstAttribute="leading" secondItem="HbG-CF-Oqd" secondAttribute="trailing" constant="16" id="F3N-MN-Exb"/>
+                <constraint firstAttribute="trailing" secondItem="CPr-he-XXd" secondAttribute="trailing" priority="249" constant="32" id="JEr-pg-mxz"/>
                 <constraint firstItem="Mbf-ep-nbj" firstAttribute="top" secondItem="XXP-Ea-Yt4" secondAttribute="top" constant="16" id="S3U-Fd-wym"/>
                 <constraint firstItem="CPr-he-XXd" firstAttribute="top" secondItem="KSx-w5-sbK" secondAttribute="top" constant="-1" id="W2W-es-ou0"/>
                 <constraint firstItem="HbG-CF-Oqd" firstAttribute="top" secondItem="CPr-he-XXd" secondAttribute="bottom" constant="16" id="b5z-mV-ODV"/>
                 <constraint firstItem="AH2-H9-2Dt" firstAttribute="centerY" secondItem="Mbf-ep-nbj" secondAttribute="centerY" id="bwB-Z1-RRr"/>
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="UDP-xQ-Pdx" secondAttribute="trailing" constant="16" id="cbE-wm-b1g"/>
-                <constraint firstItem="AH2-H9-2Dt" firstAttribute="leading" secondItem="CPr-he-XXd" secondAttribute="trailing" constant="16" id="ndm-ak-doY"/>
+                <constraint firstItem="AH2-H9-2Dt" firstAttribute="leading" secondItem="CPr-he-XXd" secondAttribute="trailing" priority="999" constant="16" id="ndm-ak-doY"/>
                 <constraint firstAttribute="bottom" secondItem="HbG-CF-Oqd" secondAttribute="bottom" constant="16" id="oMz-ah-sEg"/>
                 <constraint firstAttribute="trailing" secondItem="AH2-H9-2Dt" secondAttribute="trailing" constant="16" id="q8W-lZ-aiI"/>
                 <constraint firstItem="kN4-J7-3O6" firstAttribute="bottom" secondItem="XXP-Ea-Yt4" secondAttribute="bottom" id="qip-QH-gNJ"/>

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - AndesUI (1.2.1)
+  - AndesUI (1.3.1)
   - IQKeyboardManagerSwift (6.3.0)
   - Nimble (7.3.4)
   - Quick (1.2.0)
@@ -21,7 +21,7 @@ EXTERNAL SOURCES:
     :path: "./"
 
 SPEC CHECKSUMS:
-  AndesUI: 65201939c9c095c15810f14c01f944a8db7a6747
+  AndesUI: 9748631b19f958040b4ec8f502ba7cf0078da0bb
   IQKeyboardManagerSwift: a8228c257614af98743b4cd8584637025f36358f
   Nimble: 051e3d8912d40138fa5591c78594f95fb172af37
   Quick: 58d203b1c5e27fff7229c4c1ae445ad7069a7a08


### PR DESCRIPTION
FIx andes message constraints when dismiss is hidden
## Affected component
AndesMessage
## Screenshots
![Screen Shot 2020-02-13 at 11 47 10](https://user-images.githubusercontent.com/57450033/74446495-b93a9680-4e56-11ea-89f6-70e971582b55.png)
![Screen Shot 2020-02-13 at 11 47 29](https://user-images.githubusercontent.com/57450033/74446497-ba6bc380-4e56-11ea-9198-09218e13ab09.png)


## Checks
Are you sure you followed all those steps? If so, repeat after me "I solemnly swear that ...":
   - [x] I have coded an example inside the Demo App,
   - [ ] I have added proper tests,
   - [x] I have modified the Changelog.md file,
   - [ ] I have updated GitHub wiki,
   - [ ] I have the explicit approval of one or more members of the UX Team,
   - [ ] I have checked that this code is ObjC compliant.
## Change type
This is easy, let us know what this code is about:
   - [ ] This code adds a new component
   - [x] This code includes improvements to an existent component
   - [ ] This code improves or modifies ONLY the Demo App.