### PR TITLE
Feature/update message buttonpressed color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
-# v1.4.0 (Sin Publicar):
+# v2.0.0 (Sin Publicar):
 ## Added
+- AndesColors fix for objc
 - AndesStylesheet updated to latest definitions
 - AndesIconsProvider with local strategy to load icons from images.xcassets
 - AndesMessage: fixes in constraints when dismiss is hidden

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,12 @@
 # v2.0.0 (Sin Publicar):
-## Added
+## Changed
 - AndesColors fix for objc
 - AndesStylesheet updated to latest definitions
-- AndesIconsProvider with local strategy to load icons from images.xcassets
 - AndesMessage: fixes in constraints when dismiss is hidden
+- AndesMessage: updated button colors to new definition
+
+## Added
+- AndesIconsProvider with local strategy to load icons from images.xcassets
 
 # v1.3.1:
 ## Changed

--- a/Example/AndesUI/AndesUIAppDelegate.swift
+++ b/Example/AndesUI/AndesUIAppDelegate.swift
@@ -19,7 +19,6 @@ class AndesUIAppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
 
-        AndesStyleSheetManager.styleSheet = AndesStyleSheetDefault()
         setupIQKeyboardManager()
         UINavigationBar.appearance().barTintColor = AndesStyleSheetManager.styleSheet.accentColor
         UINavigationBar.appearance().tintColor = AndesStyleSheetManager.styleSheet.bgColorWhite

--- a/LibraryComponents/Classes/AndesMessage/Hierarchy/AndesMessageHierarchyLoud.swift
+++ b/LibraryComponents/Classes/AndesMessage/Hierarchy/AndesMessageHierarchyLoud.swift
@@ -26,6 +26,6 @@ struct AndesMessageHierarchyLoud: AndesMessageHierarchyProtocol {
         pipeColor = type.primaryColor
         accentColor = type.secondaryColor
         primaryButtonHierarchy = PrimaryMessageActionButtonHierarchy(backgroundColor: type.secondaryColor, pressedColor: type.primaryButtonPressedColor)
-        secondaryButtonHierarchy = SecondaryMessageActionButtonHierarchy(textColor: textColor, pressedColor: type.secondaryColor)
+        secondaryButtonHierarchy = SecondaryMessageActionButtonHierarchy(textColor: textColor, pressedColor: type.secondaryButtonPressedColor)
     }
 }

--- a/LibraryComponents/Classes/AndesMessage/Type/AndesMessageTypeError.swift
+++ b/LibraryComponents/Classes/AndesMessage/Type/AndesMessageTypeError.swift
@@ -9,6 +9,7 @@ import Foundation
 class AndesMessageTypeError: AndesMessageTypeProtocol {
     var primaryColor: UIColor = UIColor.Andes.red500
     var secondaryColor: UIColor = UIColor.Andes.red600
-    var primaryButtonPressedColor: UIColor = UIColor.Andes.red700
+    var primaryButtonPressedColor: UIColor = UIColor.Andes.red800
+    var secondaryButtonPressedColor: UIColor = UIColor.Andes.red700
     var icon: String = AndesIcons.feedbackError16
 }

--- a/LibraryComponents/Classes/AndesMessage/Type/AndesMessageTypeHightlight.swift
+++ b/LibraryComponents/Classes/AndesMessage/Type/AndesMessageTypeHightlight.swift
@@ -9,6 +9,7 @@ import Foundation
 class AndesMessageTypeHightlight: AndesMessageTypeProtocol {
     var primaryColor: UIColor = AndesStyleSheetManager.styleSheet.accentColor
     var secondaryColor: UIColor = AndesStyleSheetManager.styleSheet.accentColor600
-    var primaryButtonPressedColor: UIColor = AndesStyleSheetManager.styleSheet.accentColor700
+    var primaryButtonPressedColor: UIColor = AndesStyleSheetManager.styleSheet.accentColor800
+    var secondaryButtonPressedColor: UIColor = AndesStyleSheetManager.styleSheet.accentColor700
     var icon: String = AndesIcons.feedbackInfo16
 }

--- a/LibraryComponents/Classes/AndesMessage/Type/AndesMessageTypeProtocol.swift
+++ b/LibraryComponents/Classes/AndesMessage/Type/AndesMessageTypeProtocol.swift
@@ -11,5 +11,6 @@ internal protocol AndesMessageTypeProtocol {
     var primaryColor: UIColor { get }
     var secondaryColor: UIColor { get }
     var primaryButtonPressedColor: UIColor { get }
+    var secondaryButtonPressedColor: UIColor { get }
     var icon: String { get }
 }

--- a/LibraryComponents/Classes/AndesMessage/Type/AndesMessageTypeSuccess.swift
+++ b/LibraryComponents/Classes/AndesMessage/Type/AndesMessageTypeSuccess.swift
@@ -9,6 +9,7 @@ import Foundation
 class AndesMessageTypeSuccess: AndesMessageTypeProtocol {
     var primaryColor: UIColor = UIColor.Andes.green500
     var secondaryColor: UIColor = UIColor.Andes.green600
-    var primaryButtonPressedColor: UIColor = UIColor.Andes.green700
+    var primaryButtonPressedColor: UIColor = UIColor.Andes.green800
+    var secondaryButtonPressedColor: UIColor = UIColor.Andes.green700
     var icon: String = AndesIcons.feedbackSuccess16
 }

--- a/LibraryComponents/Classes/AndesMessage/Type/AndesMessageTypeWarning.swift
+++ b/LibraryComponents/Classes/AndesMessage/Type/AndesMessageTypeWarning.swift
@@ -9,6 +9,7 @@ import Foundation
 class AndesMessageTypeWarning: AndesMessageTypeProtocol {
     var primaryColor: UIColor = UIColor.Andes.orange500
     var secondaryColor: UIColor = UIColor.Andes.orange600
-    var primaryButtonPressedColor: UIColor = UIColor.Andes.orange700
+    var primaryButtonPressedColor: UIColor = UIColor.Andes.orange800
+    var secondaryButtonPressedColor: UIColor = UIColor.Andes.orange700
     var icon: String = AndesIcons.feedbackWarning16
 }

--- a/LibraryComponents/Classes/Stylesheet/AndesColor.swift
+++ b/LibraryComponents/Classes/Stylesheet/AndesColor.swift
@@ -7,76 +7,76 @@
 
 import Foundation
 
-@objc public extension UIColor {
+@objc extension UIColor {
     /// Andes Color Palette
-    struct Andes {
-        static let white = UIColor(hex: "#FFFFFF")!
+    @objc(AndesColors) public class Andes: NSObject {
+        @objc public static let white = UIColor(hex: "#FFFFFF")!
 
-        static let gray040 = UIColor(hex: "#0A000000")!
-        static let gray070 = UIColor(hex: "#12000000")!
-        static let gray100 = UIColor(hex: "#1A000000")!
-        static let gray250 = UIColor(hex: "#40000000")!
-        static let gray450 = UIColor(hex: "#73000000")!
-        static let gray800 = UIColor(hex: "#CC000000")!
+        @objc public static let gray040 = UIColor(hex: "#0A000000")!
+        @objc public static let gray070 = UIColor(hex: "#12000000")!
+        @objc public static let gray100 = UIColor(hex: "#1A000000")!
+        @objc public static let gray250 = UIColor(hex: "#40000000")!
+        @objc public static let gray450 = UIColor(hex: "#73000000")!
+        @objc public static let gray800 = UIColor(hex: "#CC000000")!
 
-        static let graySolid040 = UIColor(hex: "#F5F5F5")!
-        static let graySolid070 = UIColor(hex: "#EDEDED")!
-        static let graySolid100 = UIColor(hex: "#E5E5E5")!
-        static let graySolid250 = UIColor(hex: "#B5B5B5")!
-        static let graySolid450 = UIColor(hex: "#8C8C8C")!
-        static let graySolid800 = UIColor(hex: "#333333")!
+        @objc public static let graySolid040 = UIColor(hex: "#F5F5F5")!
+        @objc public static let graySolid070 = UIColor(hex: "#EDEDED")!
+        @objc public static let graySolid100 = UIColor(hex: "#E5E5E5")!
+        @objc public static let graySolid250 = UIColor(hex: "#B5B5B5")!
+        @objc public static let graySolid450 = UIColor(hex: "#8C8C8C")!
+        @objc public static let graySolid800 = UIColor(hex: "#333333")!
 
-        static let yellowML500 = UIColor(hex: "#FFE602")!
+        @objc public static let yellowML500 = UIColor(hex: "#FFE602")!
 
-        static let blueML100 = UIColor(hex: "#1A4189E6")!
-        static let blueML150 = UIColor(hex: "#264189E6")!
-        static let blueML200 = UIColor(hex: "#334189E6")!
-        static let blueML300 = UIColor(hex: "#4D4189E6")!
-        static let blueML400 = UIColor(hex: "#664189E6")!
-        static let blueML500 = UIColor(hex: "#3483FA")!
-        static let blueML600 = UIColor(hex: "#2968C8")!
-        static let blueML700 = UIColor(hex: "#1F4E96")!
-        static let blueML800 = UIColor(hex: "#183C73")!
+        @objc public static let blueML100 = UIColor(hex: "#1A4189E6")!
+        @objc public static let blueML150 = UIColor(hex: "#264189E6")!
+        @objc public static let blueML200 = UIColor(hex: "#334189E6")!
+        @objc public static let blueML300 = UIColor(hex: "#4D4189E6")!
+        @objc public static let blueML400 = UIColor(hex: "#664189E6")!
+        @objc public static let blueML500 = UIColor(hex: "#3483FA")!
+        @objc public static let blueML600 = UIColor(hex: "#2968C8")!
+        @objc public static let blueML700 = UIColor(hex: "#1F4E96")!
+        @objc public static let blueML800 = UIColor(hex: "#183C73")!
 
-        static let blueMP100 = UIColor(hex: "#1A479AD1")!
-        static let blueMP150 = UIColor(hex: "#26479AD1")!
-        static let blueMP200 = UIColor(hex: "#33479AD1")!
-        static let blueMP300 = UIColor(hex: "#4D479AD1")!
-        static let blueMP400 = UIColor(hex: "#66479AD1")!
-        static let blueMP500 = UIColor(hex: "#3483FA")!
-        static let blueMP600 = UIColor(hex: "#2968C8")!
-        static let blueMP700 = UIColor(hex: "#1F4E96")!
-        static let blueMP800 = UIColor(hex: "#004766")!
+        @objc public static let blueMP100 = UIColor(hex: "#1A479AD1")!
+        @objc public static let blueMP150 = UIColor(hex: "#26479AD1")!
+        @objc public static let blueMP200 = UIColor(hex: "#33479AD1")!
+        @objc public static let blueMP300 = UIColor(hex: "#4D479AD1")!
+        @objc public static let blueMP400 = UIColor(hex: "#66479AD1")!
+        @objc public static let blueMP500 = UIColor(hex: "#3483FA")!
+        @objc public static let blueMP600 = UIColor(hex: "#2968C8")!
+        @objc public static let blueMP700 = UIColor(hex: "#1F4E96")!
+        @objc public static let blueMP800 = UIColor(hex: "#004766")!
 
-        static let green100 = UIColor(hex: "#1A00A650")!
-        static let green150 = UIColor(hex: "#2600A650")!
-        static let green200 = UIColor(hex: "#3300A650")!
-        static let green300 = UIColor(hex: "#4D00A650")!
-        static let green400 = UIColor(hex: "#6600A650")!
-        static let green500 = UIColor(hex: "#00A650")!
-        static let green600 = UIColor(hex: "#008744")!
-        static let green700 = UIColor(hex: "#006633")!
-        static let green800 = UIColor(hex: "#004D27")!
+        @objc public static let green100 = UIColor(hex: "#1A00A650")!
+        @objc public static let green150 = UIColor(hex: "#2600A650")!
+        @objc public static let green200 = UIColor(hex: "#3300A650")!
+        @objc public static let green300 = UIColor(hex: "#4D00A650")!
+        @objc public static let green400 = UIColor(hex: "#6600A650")!
+        @objc public static let green500 = UIColor(hex: "#00A650")!
+        @objc public static let green600 = UIColor(hex: "#008744")!
+        @objc public static let green700 = UIColor(hex: "#006633")!
+        @objc public static let green800 = UIColor(hex: "#004D27")!
 
-        static let orange100 = UIColor(hex: "#1AFF7733")!
-        static let orange150 = UIColor(hex: "#26FF7733")!
-        static let orange200 = UIColor(hex: "#33FF7733")!
-        static let orange300 = UIColor(hex: "#4DFF7733")!
-        static let orange400 = UIColor(hex: "#66FF7733")!
-        static let orange500 = UIColor(hex: "#FF7733")!
-        static let orange600 = UIColor(hex: "#E6540B")!
-        static let orange700 = UIColor(hex: "#CC3E0A")!
-        static let orange800 = UIColor(hex: "#A62A08")!
+        @objc public static let orange100 = UIColor(hex: "#1AFF7733")!
+        @objc public static let orange150 = UIColor(hex: "#26FF7733")!
+        @objc public static let orange200 = UIColor(hex: "#33FF7733")!
+        @objc public static let orange300 = UIColor(hex: "#4DFF7733")!
+        @objc public static let orange400 = UIColor(hex: "#66FF7733")!
+        @objc public static let orange500 = UIColor(hex: "#FF7733")!
+        @objc public static let orange600 = UIColor(hex: "#E6540B")!
+        @objc public static let orange700 = UIColor(hex: "#CC3E0A")!
+        @objc public static let orange800 = UIColor(hex: "#A62A08")!
 
-        static let red100 = UIColor(hex: "#1AF23D4F")!
-        static let red150 = UIColor(hex: "#26F23D4F")!
-        static let red200 = UIColor(hex: "#33F23D4F")!
-        static let red300 = UIColor(hex: "#4DF23D4F")!
-        static let red400 = UIColor(hex: "#66F23D4F")!
-        static let red500 = UIColor(hex: "#F23D4F")!
-        static let red600 = UIColor(hex: "#D12440")!
-        static let red700 = UIColor(hex: "#A61D33")!
-        static let red800 = UIColor(hex: "#801627")!
+        @objc public static let red100 = UIColor(hex: "#1AF23D4F")!
+        @objc public static let red150 = UIColor(hex: "#26F23D4F")!
+        @objc public static let red200 = UIColor(hex: "#33F23D4F")!
+        @objc public static let red300 = UIColor(hex: "#4DF23D4F")!
+        @objc public static let red400 = UIColor(hex: "#66F23D4F")!
+        @objc public static let red500 = UIColor(hex: "#F23D4F")!
+        @objc public static let red600 = UIColor(hex: "#D12440")!
+        @objc public static let red700 = UIColor(hex: "#A61D33")!
+        @objc public static let red800 = UIColor(hex: "#801627")!
     }
 }
 


### PR DESCRIPTION

## Description
After changing to the new stylesheet, the colors for andes message buttons changed
## Affected component
Message
## UX def
![image (2)](https://user-images.githubusercontent.com/57450033/75482331-5fbc8680-5983-11ea-9519-661ab976a581.png)

## Screenshots

![Screen-Recording-2020-02-27-at-14 29 26](https://user-images.githubusercontent.com/57450033/75481104-487c9980-5981-11ea-9742-19a8f53adfe7.gif)
## Checks
Are you sure you followed all those steps? If so, repeat after me "I solemnly swear that ...":
   - [ ] I have coded an example inside the Demo App,
   - [ ] I have added proper tests,
   - [X] I have modified the Changelog.md file,
   - [ ] I have updated GitHub wiki,
   - [X] I have the explicit approval of one or more members of the UX Team,
   - [ ] I have checked that this code is ObjC compliant.
## Change type
This is easy, let us know what this code is about:
   - [ ] This code adds a new component
   - [X] This code includes improvements to an existent component
   - [ ] This code improves or modifies ONLY the Demo App.