### PR TITLE
Feature/remove ios11 strat

### DIFF
--- a/AndesUI.podspec
+++ b/AndesUI.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'AndesUI'
-  s.version          = '2.1.3'
+  s.version          = '2.1.4'
   s.summary          = 'AndesUI library for ios app.'
 
   s.description      = 'AndesUI is the UI library of Mercado Libre. It provides the definitions, components and tools to build consistent experiences, with agility and visual quality.'

--- a/AndesUI.podspec
+++ b/AndesUI.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'AndesUI'
-  s.version          = '2.1.4'
+  s.version          = '2.1.5'
   s.summary          = 'AndesUI library for ios app.'
 
   s.description      = 'AndesUI is the UI library of Mercado Libre. It provides the definitions, components and tools to build consistent experiences, with agility and visual quality.'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,14 @@
+# v2.1.5:
+## Changed
+- Temporary removal of ios11 color strategy for issue loading bundle with new build system
+
 # v2.1.4:
 ## Fixed
-AndesIconsProvider loadIcon signature fix. (success callbacks gets a non nullable UIImage instead of nullable)
+- AndesIconsProvider loadIcon signature fix. (success callbacks gets a non nullable UIImage instead of nullable)
 
 # v2.1.3:
 ## Fixed
-Change access level to AndesIconsProvider methods 
+- Change access level to AndesIconsProvider methods 
 
 # v2.1.2:
 ## Fixed

--- a/LibraryComponents/Classes/Stylesheet/AndesStyleSheetDefault.swift
+++ b/LibraryComponents/Classes/Stylesheet/AndesStyleSheetDefault.swift
@@ -42,12 +42,8 @@ import Foundation
     public lazy var feedbackColorNegative: UIColor = self.stylesheetStrategy.feedbackColorNegative
 
     public override init() {
-        //TODO: Remove when iOS 11 is minimum deployment target
-        if #available(iOS 11.0, *) {
-            self.stylesheetStrategy = AndesColorStrategyiOS11()
-        } else {
-            self.stylesheetStrategy = AndesColorStrategyiOS10()
-        }
+        //TODO: Remove when iOS 11 is minimum deployment target, use ios 11 strat when new build system issues are solved
+        self.stylesheetStrategy = AndesColorStrategyiOS10()
     }
 
     public func titleXL(color: UIColor) -> AndesFontStyle {


### PR DESCRIPTION
New Build system issue when loading bundle, removed ios11 strat that forces unwrapes bundle calls until this issue is sorted.