### PR TITLE
fix error helper font

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-## v2.2.0 Unpublished
+## v3.0.0 Unpublished
+### 🛠 Bug fixes
+- AndesTextField/Area: Helper text font weight on error state is always semibold.
+
+## v2.2.0
 ### 🚀 Features
 - AndesBadge: Pill modifier | Authors: [@ignaguri](https://github.com/ignaguri)
 - AndesTextField | Authors: [@Mobile-Arq](https://github.com/mercadolibre/fury_andesui-ios)

--- a/LibraryComponents/Classes/AndesTextField/State/AndesTextFieldStateError.swift
+++ b/LibraryComponents/Classes/AndesTextField/State/AndesTextFieldStateError.swift
@@ -16,7 +16,7 @@ struct AndesTextFieldStateError: AndesTextFieldStateProtocol {
     var helperColor = AndesStyleSheetManager.styleSheet.textColorNegative
     var helperIconTintColor: UIColor? = AndesStyleSheetManager.styleSheet.textColorWhite
     var helperIconName: String? = "andes_ui_feedback_error_16"
-    var helperSemibold: Bool = false
+    var helperSemibold: Bool = true
 
     var backgroundColor = AndesStyleSheetManager.styleSheet.bgColorWhite
     var inputTextColor = AndesStyleSheetManager.styleSheet.textColorPrimary
@@ -28,7 +28,6 @@ struct AndesTextFieldStateError: AndesTextFieldStateProtocol {
         if focuesd {
             backgroundColor = AndesStyleSheetManager.styleSheet.bgColorWhite
             borderWidth = 2
-            self.helperSemibold = true
         }
     }
 }


### PR DESCRIPTION
Helper error text should always be semibold, not only on focus
## Checks
Are you sure you followed all those steps? If so, repeat after me "I solemnly swear that ...":
   - [ ] I have coded an example inside the Demo App,
   - [ ] I have added proper tests,
   - [x] I have modified the Changelog.md file,
   - [ ] I have updated GitHub wiki,
   - [ ] I have the explicit approval of one or more members of the UX Team,
   - [ ] I have checked that this code is ObjC compliant.
   - [ ] I have checked that all the new public enums conform to AndesEnumStringConvertible.
## Change type
This is easy, let us know what this code is about:
   - [ ] This code adds a new component
   - [x] This code includes improvements to an existent component
   - [ ] This code improves or modifies ONLY the Demo App.