### PR TITLE
Badge Dot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 ## Unpublished
+
+### 🚀 Features
+- AndesBadge: Dot modifier | Authors: [@Mobile-Arq](https://github.com/mercadolibre/fury_andesui-ios)
+
 ### 🛠 Bug fixes
 - AndesMessage, UILabel.SetAndesStyle: Spacing fix | Authors: [@Mobile-Arq](https://github.com/mercadolibre/fury_andesui-ios)
 ### ⚙️ Other

--- a/Example/AndesUI/Badges/Views/BadgeObjCViewController.m
+++ b/Example/AndesUI/Badges/Views/BadgeObjCViewController.m
@@ -89,6 +89,34 @@
     [oddCasesStack addArrangedSubview:oddBadge];
     
     [_stackView addArrangedSubview:oddCasesStack];
+    
+    UILabel* dotTitle = [[UILabel alloc] initWithFrame:CGRectZero];
+    dotTitle.text = @"Dot";
+    dotTitle.font = [UIFont systemFontOfSize:24];
+    [_stackView addArrangedSubview:dotTitle];
+    
+    UIStackView* allDots = [[UIStackView alloc] init];
+    allDots.axis = UILayoutConstraintAxisVertical;
+    allDots.alignment = UIStackViewAlignmentCenter;
+    allDots.distribution = UIStackViewDistributionFillProportionally;
+    allDots.spacing = 8.0;
+    
+    AndesBadgeDot *neutralDot = [[AndesBadgeDot alloc] initWithType:AndesBadgeTypeNeutral];
+    [allDots addArrangedSubview:neutralDot];
+    
+    AndesBadgeDot *highlightDot = [[AndesBadgeDot alloc] initWithType:AndesBadgeTypeHighlight];
+    [allDots addArrangedSubview:highlightDot];
+    
+    AndesBadgeDot *successtDot = [[AndesBadgeDot alloc] initWithType:AndesBadgeTypeSuccess];
+    [allDots addArrangedSubview:successtDot];
+    
+    AndesBadgeDot *warningDot = [[AndesBadgeDot alloc] initWithType:AndesBadgeTypeWarning];
+    [allDots addArrangedSubview:warningDot];
+    
+    AndesBadgeDot *errorDot = [[AndesBadgeDot alloc] initWithType:AndesBadgeTypeError];
+    [allDots addArrangedSubview:errorDot];
+    
+    [_stackView addArrangedSubview:allDots];
 }
 
 - (void)addPillsWithHierarchy:(AndesBadgeHierarchy)hierarchy toStack:(UIStackView*)stack {

--- a/Example/AndesUI/Badges/Views/BadgeViewController.swift
+++ b/Example/AndesUI/Badges/Views/BadgeViewController.swift
@@ -11,13 +11,16 @@ protocol BadgeView: NSObject {
 }
 
 /// Used to define the type of an AndesBadge
-enum AndesBadgeModifier: String {
-    case pill = "PILL"
+enum AndesBadgeModifier: Int {
+    case pill = 0
+    case dot
 }
 
 class BadgeViewController: UIViewController, BadgeView {
 
-    @IBOutlet weak var badgeView: AndesBadgePill!
+    @IBOutlet weak var badgePillView: AndesBadgePill!
+    @IBOutlet weak var badgeDotView: AndesBadgeDot!
+
     @IBOutlet weak var updateButton: AndesButton!
 
     @IBOutlet weak var modifierField: UITextField!
@@ -49,17 +52,42 @@ class BadgeViewController: UIViewController, BadgeView {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        setupBaseBadge()
+        setupBadge()
         setupUpdateButton()
         createPickerViews()
     }
 
-    func setupBaseBadge() {
-        badgeView.text = self.textField.text ?? ""
-        badgeView.hierarchy = self.hierarchy
-        badgeView.type = self.type
-        badgeView.size = self.size
-        badgeView.border = self.border
+    func setupBadge() {
+        hideAll()
+        switch self.modifier {
+        case .pill:
+            setupBadgePill()
+        default:
+            setupBadgeDot()
+        }
+    }
+
+    func hideAll() {
+        badgePillView.isHidden = true
+        badgeDotView.isHidden = true
+    }
+
+    func setupBadgePill() {
+        enableAllComponentes(enabled: true)
+        badgePillView.isHidden = false
+        badgePillView.text = self.textField.text ?? ""
+        badgePillView.hierarchy = self.hierarchy
+        badgePillView.type = self.type
+        badgePillView.size = self.size
+        badgePillView.border = self.border
+    }
+
+    func setupBadgeDot() {
+        enableAllComponentes(enabled: false)
+        enableField(field: typeField, enabled: true)
+
+        badgeDotView.isHidden = false
+        badgeDotView.type = self.type
     }
 
     func setupUpdateButton() {
@@ -94,9 +122,21 @@ class BadgeViewController: UIViewController, BadgeView {
     }
 
     @IBAction func updateButtonTouched(_ sender: Any) {
-        setupBaseBadge()
+        setupBadge()
     }
 
+    func enableAllComponentes(enabled: Bool) {
+        enableField(field: hierarchyField, enabled: enabled)
+        enableField(field: typeField, enabled: enabled)
+        enableField(field: sizeField, enabled: enabled)
+        enableField(field: borderField, enabled: enabled)
+        enableField(field: textField, enabled: enabled)
+    }
+
+    func enableField(field: UITextField, enabled: Bool) {
+        field.isEnabled = enabled
+        field.alpha = enabled ? 1.0 : 0.3
+    }
 }
 
 extension BadgeViewController: UIPickerViewDelegate {
@@ -104,7 +144,7 @@ extension BadgeViewController: UIPickerViewDelegate {
         switch pickerView {
         case modifierPicker:
             modifierField.resignFirstResponder()
-            self.modifier = AndesBadgeModifier.pill
+            self.modifier = AndesBadgeModifier.init(rawValue: row)!
             modifierField.text = modifier.toString()
         case hierarchyPicker:
             hierarchyField.resignFirstResponder()
@@ -136,7 +176,7 @@ extension BadgeViewController: UIPickerViewDataSource {
     func pickerView(_ pickerView: UIPickerView, numberOfRowsInComponent component: Int) -> Int {
         switch pickerView {
         case modifierPicker:
-            return 1
+            return 2
         case hierarchyPicker:
             return 2
         case typePicker:
@@ -153,7 +193,7 @@ extension BadgeViewController: UIPickerViewDataSource {
     func pickerView(_ pickerView: UIPickerView, titleForRow row: Int, forComponent component: Int) -> String? {
         switch pickerView {
         case modifierPicker:
-            return AndesBadgeModifier.pill.rawValue
+            return AndesBadgeModifier.init(rawValue: row)!.toString()
         case hierarchyPicker:
             return AndesBadgeHierarchy.init(rawValue: row)!.toString()
         case typePicker:
@@ -173,6 +213,8 @@ extension AndesBadgeModifier {
         switch self {
         case .pill:
             return "Pill"
+        case .dot:
+            return "Dot"
         }
     }
 }

--- a/Example/AndesUI/Badges/Views/BadgeViewController.xib
+++ b/Example/AndesUI/Badges/Views/BadgeViewController.xib
@@ -1,16 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16096" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15705" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15706"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="BadgeViewController" customModule="AndesUI_DemoApp" customModuleProvider="target">
             <connections>
-                <outlet property="badgeView" destination="V1H-My-lQr" id="Vym-3o-7F5"/>
+                <outlet property="badgeDotView" destination="Jm9-UB-YER" id="ZcZ-53-Fox"/>
+                <outlet property="badgePillView" destination="V1H-My-lQr" id="uip-2c-oSv"/>
                 <outlet property="borderField" destination="Ega-y5-JZs" id="XcO-Fj-JhD"/>
                 <outlet property="hierarchyField" destination="Ygx-X9-u7f" id="V6P-bL-3gc"/>
                 <outlet property="modifierField" destination="UFa-QP-Euv" id="Pqs-NB-UGa"/>
@@ -170,12 +171,19 @@
                         <constraint firstItem="ae8-Zp-qWR" firstAttribute="top" secondItem="Gsi-oW-lg8" secondAttribute="top" constant="12" id="zhy-ue-tFz"/>
                     </constraints>
                 </view>
+                <view contentMode="scaleToFill" placeholderIntrinsicWidth="8" placeholderIntrinsicHeight="8" translatesAutoresizingMaskIntoConstraints="NO" id="Jm9-UB-YER" customClass="AndesBadgeDot" customModule="AndesUI">
+                    <rect key="frame" x="203" y="84" width="8" height="8"/>
+                    <color key="backgroundColor" systemColor="systemBlueColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                </view>
             </subviews>
             <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
             <constraints>
+                <constraint firstItem="xV9-wb-mRB" firstAttribute="top" secondItem="Jm9-UB-YER" secondAttribute="bottom" constant="72" id="46w-ne-e2h"/>
+                <constraint firstItem="Jm9-UB-YER" firstAttribute="centerX" secondItem="i5M-Pr-FkT" secondAttribute="centerX" id="8NY-ed-yv2"/>
                 <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="Gsi-oW-lg8" secondAttribute="trailing" id="CK7-eQ-qAY"/>
                 <constraint firstItem="xV9-wb-mRB" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" constant="32" id="Esg-hQ-DTp"/>
                 <constraint firstItem="V1H-My-lQr" firstAttribute="top" secondItem="fnl-2z-Ty3" secondAttribute="top" constant="32" id="FSt-R3-pIx"/>
+                <constraint firstItem="Jm9-UB-YER" firstAttribute="top" secondItem="fnl-2z-Ty3" secondAttribute="top" constant="40" id="RX3-Gq-6jG"/>
                 <constraint firstItem="V1H-My-lQr" firstAttribute="centerX" secondItem="i5M-Pr-FkT" secondAttribute="centerX" id="V5R-He-PTt"/>
                 <constraint firstItem="xV9-wb-mRB" firstAttribute="top" secondItem="V1H-My-lQr" secondAttribute="bottom" constant="64" id="cFr-Bb-Xfz"/>
                 <constraint firstItem="Gsi-oW-lg8" firstAttribute="top" secondItem="xV9-wb-mRB" secondAttribute="bottom" constant="24" id="i1O-ql-OId"/>

--- a/Example/AndesUI/PageController/AndesShowcasePageViewController.swift
+++ b/Example/AndesUI/PageController/AndesShowcasePageViewController.swift
@@ -47,7 +47,7 @@ class AndesShowcasePageViewController: UIViewController {
         containerView.bringSubview(toFront: pageControl)
         setupPageControl()
         if #available(iOS 11.0, *) {} else {
-            //iOS < 10 fix https://forums.developer.apple.com/thread/87329
+            //iOS <= 10 fix https://forums.developer.apple.com/thread/87329
             guard let topBarHeight = self.navigationController?.navigationBar.frame.height else {
                 return
             }

--- a/Example/Tests/AndesBadgeTests.swift
+++ b/Example/Tests/AndesBadgeTests.swift
@@ -62,6 +62,31 @@ class AndesBadgeTests: QuickSpec {
                     expect(contentView.layer.cornerRadius).to(equal(AndesBadgeSizeSmall().borderRadius))
                 }
             }
+
+            context("Badge Modifier: Dot") {
+                it("A Badge Dot by default should be neutral") {
+                    // Given
+                    let defaultType = AndesBadgeType.neutral
+
+                    // When
+                    let badge = AndesBadgeDot(frame: .zero)
+
+                    // Then
+                    expect(badge.type).to(equal(defaultType))
+                }
+                it("Set the right type when is custom") {
+                    // Given
+                    let highlightType = AndesBadgeType.highlight
+
+                    // When
+                    let badge = AndesBadgeDot(frame: .zero)
+                    badge.type = highlightType
+
+                    // Then
+                    expect(badge.type).to(equal(highlightType))
+                }
+            }
+
         }
         describe("AndesBadge should be able to change its UI dinamically") {
             context("AndesBadgePill view") {
@@ -114,6 +139,27 @@ class AndesBadgeTests: QuickSpec {
                     expect(contentView.bottom.constant).to(equal(sizeStyle.verticalPadding))
                     expect(contentView.left.constant).to(equal(sizeStyle.horizontalPadding))
                     expect(contentView.right.constant).to(equal(sizeStyle.horizontalPadding))
+                }
+            }
+
+            context("AndesBadgeDot view") {
+                var badge: AndesBadgeDot = AndesBadgeDot(frame: .zero)
+                var contentView: AndesBadgeViewDot = badge.contentView as! AndesBadgeViewDot
+
+                beforeEach {
+                    badge = AndesBadgeDot(frame: .zero)
+                    contentView = badge.contentView as! AndesBadgeViewDot
+                }
+
+                it("changes badge type dinamycally") {
+                    //Given
+                    let typeToChange: AndesBadgeType = .success
+
+                    //When
+                    badge.type = typeToChange
+
+                    //Then
+                    expect(contentView.backgroundColor).to(equal(AndesBadgeTypeFactory.provide(typeToChange).primaryColor))
                 }
             }
         }

--- a/LibraryComponents/Classes/AndesBadge/AndesBadgeDot.swift
+++ b/LibraryComponents/Classes/AndesBadge/AndesBadgeDot.swift
@@ -1,0 +1,72 @@
+//
+//  AndesBadgeDot.swift
+//  AndesUI
+//
+//  Created by Samuel Sainz on 5/13/20.
+//
+
+import Foundation
+
+@objc public class AndesBadgeDot: UIView {
+
+    internal var contentView: AndesBadgeView!
+
+    /// Defines the colors/icon of the Badge Dot
+    @objc public var type: AndesBadgeType = .neutral {
+        didSet {
+            updateContentView()
+        }
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        setup()
+    }
+
+    public override init(frame: CGRect) {
+        super.init(frame: frame)
+        setup()
+    }
+
+    @objc public init(type: AndesBadgeType) {
+        super.init(frame: .zero)
+        self.type = type
+        setup()
+    }
+
+    private func setup() {
+        translatesAutoresizingMaskIntoConstraints = false
+        self.backgroundColor = .clear
+        drawContentView(with: provideView())
+    }
+
+    private func drawContentView(with newView: AndesBadgeView) {
+        self.contentView = newView
+        addSubview(contentView)
+        leadingAnchor.constraint(equalTo: contentView.leadingAnchor).isActive = true
+        trailingAnchor.constraint(equalTo: contentView.trailingAnchor).isActive = true
+        topAnchor.constraint(equalTo: contentView.topAnchor).isActive = true
+        bottomAnchor.constraint(equalTo: contentView.bottomAnchor).isActive = true
+    }
+
+    /// Check if view needs to be redrawn, and then update it. This method should be called on all modifiers that may need to change which internal view should be rendered
+    private func reDrawContentViewIfNeededThenUpdate() {
+        let newView = provideView()
+        if Swift.type(of: newView) !== Swift.type(of: contentView) {
+            contentView.removeFromSuperview()
+            drawContentView(with: newView)
+        }
+        updateContentView()
+    }
+
+    private func updateContentView() {
+        let config = AndesBadgeViewConfigFactory.provideInternalConfig(fromDot: self)
+        contentView.update(withConfig: config)
+    }
+
+    /// Should return a view depending on which Badge modifier is selected
+    private func provideView() -> AndesBadgeView {
+        let config = AndesBadgeViewConfigFactory.provideInternalConfig(fromDot: self)
+        return AndesBadgeViewDot(withConfig: config)
+    }
+}

--- a/LibraryComponents/Classes/AndesBadge/AndesBadgePill.swift
+++ b/LibraryComponents/Classes/AndesBadge/AndesBadgePill.swift
@@ -89,13 +89,13 @@ import UIKit
     }
 
     private func updateContentView() {
-        let config = AndesBadgeViewConfigFactory.provideInternalConfig(from: self)
+        let config = AndesBadgeViewConfigFactory.provideInternalConfig(fromPill: self)
         contentView.update(withConfig: config)
     }
 
     /// Should return a view depending on which Badge modifier is selected
     private func provideView() -> AndesBadgeView {
-        let config = AndesBadgeViewConfigFactory.provideInternalConfig(from: self)
+        let config = AndesBadgeViewConfigFactory.provideInternalConfig(fromPill: self)
         return AndesBadgeViewPill(withConfig: config)
     }
 }

--- a/LibraryComponents/Classes/AndesBadge/Config/AndesBadgeViewConfig.swift
+++ b/LibraryComponents/Classes/AndesBadge/Config/AndesBadgeViewConfig.swift
@@ -7,9 +7,9 @@ import Foundation
 
 /// used to define the ui of internal AndesBadge views
 internal struct AndesBadgeViewConfig {
+
     var backgroundColor: UIColor = AndesStyleSheetManager.styleSheet.accentColor
 
-    var cornerRadius: CGFloat = 6.0
     var height: CGFloat?
     var verticalPadding: CGFloat?
     var horizontalPadding: CGFloat?
@@ -21,53 +21,29 @@ internal struct AndesBadgeViewConfig {
     var iconColor: UIColor?
     var iconBackgroundColor: UIColor?
 
+    var cornerRadius: CGFloat = 6.0
     var roundedCorners: CACornerMask = [.layerMinXMinYCorner, .layerMinXMaxYCorner, .layerMaxXMinYCorner, .layerMaxXMaxYCorner]
 
-    init() {
+    init() {}
 
-    }
-
-    init(backgroundColor: UIColor) {
+    init(backgroundColor: UIColor, text: String, sizeStyle: AndesBadgeSizeProtocol, textColor: UIColor, roundedCorners: CACornerMask) {
         self.backgroundColor = backgroundColor
-
-        let sizeStyle = AndesBadgeSizeFactory.provide(.small)
         self.cornerRadius = sizeStyle.borderRadius
         self.height = sizeStyle.height
         self.verticalPadding = sizeStyle.verticalPadding
         self.horizontalPadding = sizeStyle.horizontalPadding
-
-        textStyle = AndesBadgeViewConfig.getTextStyle(font: sizeStyle.font, color: AndesStyleSheetManager.styleSheet.textColorWhite, lineSpacing: sizeStyle.lineSpacing)
-    }
-
-    init(backgroundColor: UIColor, size: AndesBadgeSize, icon: String, iconBackgroundColor: UIColor) {
-        self.backgroundColor = backgroundColor
-
-        let sizeStyle = AndesBadgeSizeFactory.provide(size)
-        self.cornerRadius = sizeStyle.borderRadius
-        self.height = sizeStyle.height
-        self.verticalPadding = sizeStyle.verticalPadding
-        self.horizontalPadding = sizeStyle.horizontalPadding
-
-        self.icon = icon
-        self.iconBackgroundColor = iconBackgroundColor
-    }
-
-    init(backgroundColor: UIColor, text: String, size: AndesBadgeSize, textColor: UIColor, border: AndesBadgeBorder) {
-        self.backgroundColor = backgroundColor
-
-        let sizeStyle = AndesBadgeSizeFactory.provide(size)
-        self.cornerRadius = sizeStyle.borderRadius
-        self.height = sizeStyle.height
-        self.verticalPadding = sizeStyle.verticalPadding
-        self.horizontalPadding = sizeStyle.horizontalPadding
-
-        textStyle = AndesBadgeViewConfig.getTextStyle(font: sizeStyle.font, color: textColor, lineSpacing: sizeStyle.lineSpacing)
+        self.textStyle = AndesFontStyle(textColor: textColor, font: sizeStyle.font, lineSpacing: sizeStyle.lineSpacing)
         self.text = text
-
-        self.roundedCorners = AndesBadgeBorderFactory.provide(border).corners
+        self.roundedCorners = roundedCorners
     }
 
-    private static func getTextStyle(font: UIFont, color: UIColor, lineSpacing: CGFloat) -> AndesFontStyle {
-        return AndesFontStyle(textColor: color, font: font, lineSpacing: lineSpacing)
+    init(backgroundColor: UIColor, text: String, sizeStyle: AndesBadgeSizeProtocol, textColor: UIColor) {
+        self.backgroundColor = backgroundColor
+        self.cornerRadius = sizeStyle.borderRadius
+        self.height = sizeStyle.height
+        self.verticalPadding = sizeStyle.verticalPadding
+        self.horizontalPadding = sizeStyle.horizontalPadding
+        self.textStyle = AndesFontStyle(textColor: textColor, font: sizeStyle.font, lineSpacing: sizeStyle.lineSpacing)
+        self.text = text
     }
 }

--- a/LibraryComponents/Classes/AndesBadge/Config/AndesBadgeViewConfigFactory.swift
+++ b/LibraryComponents/Classes/AndesBadge/Config/AndesBadgeViewConfigFactory.swift
@@ -8,12 +8,26 @@
 import Foundation
 
 internal class AndesBadgeViewConfigFactory {
-    static func provideInternalConfig(from badge: AndesBadgePill) -> AndesBadgeViewConfig {
-        let typeIns = AndesBadgeTypeFactory.provide(badge.type)
-        let hierarchyIns = AndesBadgeHierarchyFactory.provide(badge.hierarchy, forType: typeIns)
+    static func provideInternalConfig(fromPill pill: AndesBadgePill) -> AndesBadgeViewConfig {
+        let typeIns = AndesBadgeTypeFactory.provide(pill.type)
+        let hierarchyIns = AndesBadgeHierarchyFactory.provide(pill.hierarchy, forType: typeIns)
+        let pillText = pill.text
+        let sizeStyle = AndesBadgeSizeFactory.provide(.small)
+        let roundedCorners = AndesBadgeBorderFactory.provide(pill.border).corners
 
-        let pillText = badge.text
-        let config = AndesBadgeViewConfig(backgroundColor: hierarchyIns.backgroundColor, text: pillText, size: badge.size, textColor: hierarchyIns.textColor, border: badge.border)
+        let config = AndesBadgeViewConfig(backgroundColor: hierarchyIns.backgroundColor, text: pillText, sizeStyle: sizeStyle, textColor: hierarchyIns.textColor, roundedCorners: roundedCorners)
+
+        return config
+    }
+
+    static func provideInternalConfig(fromDot dot: AndesBadgeDot) -> AndesBadgeViewConfig {
+
+        let backgroundColor = AndesBadgeTypeFactory.provide(dot.type).primaryColor
+        let dotText = ""
+        let sizeStyle = AndesBadgeSizeDot()
+        let textColor = UIColor.clear
+
+        let config = AndesBadgeViewConfig(backgroundColor: backgroundColor, text: dotText, sizeStyle: sizeStyle, textColor: textColor)
 
         return config
     }

--- a/LibraryComponents/Classes/AndesBadge/Size/AndesBadgeSizeDot.swift
+++ b/LibraryComponents/Classes/AndesBadge/Size/AndesBadgeSizeDot.swift
@@ -1,0 +1,21 @@
+//
+//  AndesBadgeSizeDot.swift
+//  AndesUI
+//
+//  Created by Samuel Sainz on 5/14/20.
+//
+
+internal struct AndesBadgeSizeDot: AndesBadgeSizeProtocol {
+
+    public var font: UIFont = AndesStyleSheetManager.styleSheet.semiboldSystemFontOfSize(size: 12)
+
+    public var lineSpacing: CGFloat = 1
+
+    public var height: CGFloat = 8
+
+    public var borderRadius: CGFloat = 4
+
+    public var verticalPadding: CGFloat = 0
+
+    public var horizontalPadding: CGFloat = 0
+}

--- a/LibraryComponents/Classes/AndesBadge/View/Dot/AndesBadgeViewDot.swift
+++ b/LibraryComponents/Classes/AndesBadge/View/Dot/AndesBadgeViewDot.swift
@@ -1,0 +1,29 @@
+//
+//  AndesBadgeViewDot.swift
+//  AndesUI
+//
+//  Created by Samuel Sainz on 5/13/20.
+//
+
+import Foundation
+
+class AndesBadgeViewDot: AndesBadgeAbstractView {
+
+    @IBOutlet weak var heightConstraint: NSLayoutConstraint!
+
+    override func loadNib() {
+        let bundle = AndesBundle.bundle()
+        bundle.loadNibNamed("AndesBadgeViewDot", owner: self, options: nil)
+    }
+
+    override func updateView() {
+        super.updateView()
+
+        heightConstraint.constant = config.height!
+
+        let cornerRadius = config.cornerRadius
+        let roundedCorners = config.roundedCorners
+
+        setCornerRadius(cornerRadius: cornerRadius, roundedCorners: roundedCorners)
+    }
+}

--- a/LibraryComponents/Classes/AndesBadge/View/Dot/AndesBadgeViewDot.xib
+++ b/LibraryComponents/Classes/AndesBadge/View/Dot/AndesBadgeViewDot.xib
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15705" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15705"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="AndesBadgeViewDot" customModule="AndesUI" customModuleProvider="target">
+            <connections>
+                <outlet property="badgeView" destination="iN0-l3-epB" id="Edt-WI-v0C"/>
+                <outlet property="heightConstraint" destination="23L-nM-zcp" id="Epo-SJ-fiJ"/>
+            </connections>
+        </placeholder>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="iN0-l3-epB">
+            <rect key="frame" x="0.0" y="0.0" width="8" height="8"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="msL-pQ-cCy">
+                    <rect key="frame" x="0.0" y="0.0" width="8" height="8"/>
+                    <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                    <constraints>
+                        <constraint firstAttribute="height" constant="8" id="23L-nM-zcp"/>
+                        <constraint firstAttribute="width" secondItem="msL-pQ-cCy" secondAttribute="height" multiplier="1:1" id="ldu-Q6-QYm"/>
+                    </constraints>
+                </view>
+            </subviews>
+            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+            <constraints>
+                <constraint firstItem="msL-pQ-cCy" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="3jP-XA-1an"/>
+                <constraint firstAttribute="trailing" secondItem="msL-pQ-cCy" secondAttribute="trailing" id="O33-Fu-tEl"/>
+                <constraint firstItem="msL-pQ-cCy" firstAttribute="bottom" secondItem="iN0-l3-epB" secondAttribute="bottom" id="X2w-bC-ATJ"/>
+                <constraint firstItem="msL-pQ-cCy" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" id="f9M-f4-Ps4"/>
+            </constraints>
+            <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
+            <point key="canvasLocation" x="105.79710144927537" y="-180.13392857142856"/>
+        </view>
+    </objects>
+</document>

--- a/LibraryComponents/Classes/AndesBadge/View/Pill/AndesBadgeViewPill.swift
+++ b/LibraryComponents/Classes/AndesBadge/View/Pill/AndesBadgeViewPill.swift
@@ -35,30 +35,6 @@ class AndesBadgeViewPill: AndesBadgeAbstractView {
         let cornerRadius = config.cornerRadius
         let roundedCorners = config.roundedCorners
 
-        if #available(iOS 11.0, *) {
-            self.layer.cornerRadius = cornerRadius
-            self.layer.maskedCorners = roundedCorners
-        } else {
-            // Fallback on earlier versions
-            var cornerMask = UIRectCorner()
-            if roundedCorners.contains(.layerMinXMinYCorner) {
-                cornerMask.insert(.topLeft)
-            }
-            if roundedCorners.contains(.layerMaxXMinYCorner) {
-                cornerMask.insert(.topRight)
-            }
-            if roundedCorners.contains(.layerMinXMaxYCorner) {
-                cornerMask.insert(.bottomLeft)
-            }
-            if roundedCorners.contains(.layerMaxXMaxYCorner) {
-                cornerMask.insert(.bottomRight)
-            }
-
-            let rectShape = CAShapeLayer()
-            rectShape.bounds = self.frame
-            rectShape.position = self.center
-            rectShape.path = UIBezierPath(roundedRect: self.bounds, byRoundingCorners: cornerMask, cornerRadii: CGSize(width: cornerRadius, height: cornerRadius)).cgPath
-            self.layer.mask = rectShape
-        }
+        self.setCornerRadius(cornerRadius: cornerRadius, roundedCorners: roundedCorners)
     }
 }

--- a/LibraryComponents/Classes/Utils/Additions/UIView+Additions.swift
+++ b/LibraryComponents/Classes/Utils/Additions/UIView+Additions.swift
@@ -31,4 +31,33 @@ internal extension UIView {
         self.topAnchor.constraint(equalTo: superview.topAnchor, constant: top).isActive = true
         self.bottomAnchor.constraint(equalTo: superview.bottomAnchor, constant: bottom).isActive = true
     }
+
+    func setCornerRadius(cornerRadius: CGFloat, roundedCorners: CACornerMask) {
+
+        if #available(iOS 11.0, *) {
+            self.layer.cornerRadius = cornerRadius
+            self.layer.maskedCorners = roundedCorners
+        } else {
+            // Fallback on earlier versions
+            var cornerMask = UIRectCorner()
+            if roundedCorners.contains(.layerMinXMinYCorner) {
+                cornerMask.insert(.topLeft)
+            }
+            if roundedCorners.contains(.layerMaxXMinYCorner) {
+                cornerMask.insert(.topRight)
+            }
+            if roundedCorners.contains(.layerMinXMaxYCorner) {
+                cornerMask.insert(.bottomLeft)
+            }
+            if roundedCorners.contains(.layerMaxXMaxYCorner) {
+                cornerMask.insert(.bottomRight)
+            }
+
+            let rectShape = CAShapeLayer()
+            rectShape.bounds = self.frame
+            rectShape.position = self.center
+            rectShape.path = UIBezierPath(roundedRect: self.bounds, byRoundingCorners: cornerMask, cornerRadii: CGSize(width: cornerRadius, height: cornerRadius)).cgPath
+            self.layer.mask = rectShape
+        }
+    }
 }

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -15,7 +15,7 @@ DEPENDENCIES:
   - Quick (~> 1.2.0)
 
 SPEC REPOS:
-  https://github.com/CocoaPods/Specs.git:
+  trunk:
     - IQKeyboardManagerSwift
     - Nimble
     - Quick


### PR DESCRIPTION
### Thanks for contributing to Andes UI!
## Motivation

Provide implementation for a new variant of the Andes Badge: Dot. 

## Description

We already have the Badge in AndesUI, and now we are adding a new variant, the Badge Dot. 

The Badge Dot allows to make a subtle highlight in content using some color.
Various dots allow categorizing or differentiating elements in contexts of high information density.

You can learn more about the Dot [here](https://company-161429.frontify.com/d/kxHCRixezmfK/n-a#/componentes/badge)!

## Affected component

It's a new component. 

## Frontify component link

[Andes Badge Dot.](https://company-161429.frontify.com/d/kxHCRixezmfK/n-a#/componentes/badge)

## Screenshots

![Simulator Screen Shot - iPhone 7 - 2020-05-14 at 16 10 58](https://user-images.githubusercontent.com/8599681/81975524-8cd11a80-95fd-11ea-93ac-b84ddcad933b.png)

## Checks
Are you sure you followed all those steps? If so, repeat after me "I solemnly swear that ...":
   - [x] I have coded an example inside the Demo App,
   - [x] I have added proper tests,
   - [x] I have modified the Changelog.md file,
   - [x] I have updated GitHub wiki,
   - [x] I have the explicit approval of one or more members of the UX Team,
   - [x] I have checked that this code is ObjC compliant.
   - [x] I have checked that all the new public enums conform to AndesEnumStringConvertible.

## Change type
This is easy, let us know what this code is about:
   - [x] This code adds a new component
   - [ ] This code includes improvements to an existent component
   - [ ] This code improves or modifies ONLY the Demo App.