### PR TITLE
AndesMessage fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 - TextField/TextArea: allows for custom input views | Authors: [@Mobile-Arq](https://github.com/mercadolibre/fury_andesui-ios)
 - TextField: add textFieldShouldReturn to public delegate | Authors: [@Mobile-Arq](https://github.com/mercadolibre/fury_andesui-ios)
 
+### 🛠 Bug fixes
+- AndesMessage: Constraints priority fix | Authors: [@MaxiTalenti](https://github.com/mercadolibre/fury_andesui-ios)
+
 # v3.4.0
 ### 🛠 Bug fixes
 - TextField, TextArea: listen to resign and becomeFirstResponder | Authors: [@Mobile-Arq](https://github.com/mercadolibre/fury_andesui-ios)

--- a/LibraryComponents/Classes/AndesMessage/View/AndesMessageAbstractView.swift
+++ b/LibraryComponents/Classes/AndesMessage/View/AndesMessageAbstractView.swift
@@ -92,7 +92,7 @@ class AndesMessageAbstractView: UIView, AndesMessageView {
 
         if config.isDismissable, let iconName = config.dismissIconName {
             self.dismissButton.isHidden = false
-            self.titleToDismissConstraint.priority = .required
+            self.titleToDismissConstraint.priority = .init(rawValue: 999)
             self.titleToSafeAreaConstraint.priority = .defaultLow
             self.dismissButton.tintColor = config.dismissIconColor
             AndesIconsProvider.loadIcon(name: iconName) {

--- a/LibraryComponents/Classes/AndesMessage/View/AndesMessageAbstractView.swift
+++ b/LibraryComponents/Classes/AndesMessage/View/AndesMessageAbstractView.swift
@@ -101,7 +101,7 @@ class AndesMessageAbstractView: UIView, AndesMessageView {
             self.dismissButton.accessibilityLabel = "Cerrar".localized()
         } else {
             self.titleToDismissConstraint.priority = .defaultLow
-            self.titleToSafeAreaConstraint.priority = .required
+            self.titleToSafeAreaConstraint.priority = .init(rawValue: 999)
             self.dismissButton.isHidden = true
         }
     }

--- a/LibraryComponents/Classes/AndesMessage/View/AndesMessageAbstractView.swift
+++ b/LibraryComponents/Classes/AndesMessage/View/AndesMessageAbstractView.swift
@@ -92,7 +92,7 @@ class AndesMessageAbstractView: UIView, AndesMessageView {
 
         if config.isDismissable, let iconName = config.dismissIconName {
             self.dismissButton.isHidden = false
-            self.titleToDismissConstraint.priority = .defaultHigh
+            self.titleToDismissConstraint.priority = .required
             self.titleToSafeAreaConstraint.priority = .defaultLow
             self.dismissButton.tintColor = config.dismissIconColor
             AndesIconsProvider.loadIcon(name: iconName) {
@@ -101,7 +101,7 @@ class AndesMessageAbstractView: UIView, AndesMessageView {
             self.dismissButton.accessibilityLabel = "Cerrar".localized()
         } else {
             self.titleToDismissConstraint.priority = .defaultLow
-            self.titleToSafeAreaConstraint.priority = .defaultHigh
+            self.titleToSafeAreaConstraint.priority = .required
             self.dismissButton.isHidden = true
         }
     }


### PR DESCRIPTION
## Description
For fix [this](https://github.com/mercadolibre/fury_andesui-ios/issues/87) bug

## Affected component
AndesMessage

## Screenshots / GIFs
### New version dismissible
![image](https://user-images.githubusercontent.com/7159779/86286221-78041280-bbbc-11ea-8106-721bc3a96ee5.png)

### New version not dismissible
![image](https://user-images.githubusercontent.com/7159779/86286365-b3064600-bbbc-11ea-8593-2c6eec9ddc11.png) 

## Checks
Are you sure you followed all those steps? If so, repeat after me "I solemnly swear that ...":
   - [ ] I have coded an example inside the Demo App,
   - [ ] I have added proper tests,
   - [X] I have modified the Changelog.md file,
   - [ ] I have updated GitHub wiki,
   - [ ] I have the explicit approval of one or more members of the UX Team,
   - [ ] I have checked that this code is ObjC compliant.
   - [ ] I have checked that all the new public enums conform to AndesEnumStringConvertible.
## Change type
This is easy, let us know what this code is about:
   - [ ] This code adds a new component
   - [x] This code includes improvements to an existent component
   - [ ] This code improves or modifies ONLY the Demo App.
