### PR TITLE
Message Body Links

### DIFF
--- a/Example/AndesUI/Messages/Views/MessageViewController.swift
+++ b/Example/AndesUI/Messages/Views/MessageViewController.swift
@@ -65,6 +65,14 @@ class MessageViewController: UIViewController, MessageView {
     fileprivate func setupBaseMessage() {
         messageView.title = "message.default.title".localized
         messageView.body = "message.default.body".localized
+
+        let links = [
+            AndesBodyLink(startIndex: 0, endIndex: 5),
+            AndesBodyLink(startIndex: 79, endIndex: 123)
+        ]
+
+        messageView.setBodyLinks(AndesBodyLinks(links: links, listener: {[unowned self] index in self.didPressBodyLink(index)}))
+
         messageView.onDismiss {[unowned self] _ in
                 self.showAgainBtn.isHidden = false
             }
@@ -83,6 +91,12 @@ class MessageViewController: UIViewController, MessageView {
 
     func didPressButton() {
         let alert = UIAlertController(title: "message.actions.pressedMsg".localized, message: "", preferredStyle: .alert)
+        alert.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
+        self.present(alert, animated: true, completion: nil)
+    }
+
+    func didPressBodyLink(_ index: Int) {
+        let alert = UIAlertController(title: "message.actions.pressedMsg".localized, message: "Body link pressed at position: \(index)", preferredStyle: .alert)
         alert.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
         self.present(alert, animated: true, completion: nil)
     }

--- a/Example/AndesUI/Messages/Views/MessageViewController.swift
+++ b/Example/AndesUI/Messages/Views/MessageViewController.swift
@@ -68,7 +68,11 @@ class MessageViewController: UIViewController, MessageView {
 
         let links = [
             AndesBodyLink(startIndex: 0, endIndex: 5),
-            AndesBodyLink(startIndex: 79, endIndex: 123)
+            AndesBodyLink(startIndex: 79, endIndex: 123),
+            AndesBodyLink(startIndex: 50, endIndex: 40),
+            AndesBodyLink(startIndex: 79, endIndex: 124),
+            AndesBodyLink(startIndex: -1, endIndex: 10),
+            AndesBodyLink(startIndex: -1, endIndex: -10)
         ]
 
         messageView.setBodyLinks(AndesBodyLinks(links: links, listener: {[unowned self] index in self.didPressBodyLink(index)}))

--- a/Example/Tests/AndesMessageTests.swift
+++ b/Example/Tests/AndesMessageTests.swift
@@ -41,7 +41,7 @@ class AndesMessageTests: QuickSpec {
                     //Then
                     expect(message.contentView.isKind(of: AndesMessageDefaultView.self)).to(beTrue())
                     expect((message.contentView as! AndesMessageDefaultView).titleLabel.text).to(match(title))
-                    expect((message.contentView as! AndesMessageDefaultView).bodyLabel.text).to(match(body))
+                    expect((message.contentView as! AndesMessageDefaultView).bodyTextView.text).to(match(body))
                     expect((message.contentView as! AndesMessageDefaultView).leftPipeView.backgroundColor) == AndesMessageTypeSuccess().primaryColor
                     expect((message.contentView as! AndesMessageDefaultView).backgroundColor) == AndesMessageHierarchyQuiet(type: AndesMessageTypeSuccess()).backgroundColor
                     }
@@ -93,7 +93,7 @@ class AndesMessageTests: QuickSpec {
                       message.body = descToChange
 
                       //Then
-                      expect((message.contentView as! AndesMessageDefaultView).bodyLabel.text).to(match(descToChange))
+                      expect((message.contentView as! AndesMessageDefaultView).bodyTextView.text).to(match(descToChange))
                   }
                 it("changes andes message view dinamycally to actionsView") {
                     //Given

--- a/Example/Tests/AndesMessageTests.swift
+++ b/Example/Tests/AndesMessageTests.swift
@@ -242,6 +242,31 @@ class AndesMessageTests: QuickSpec {
                     expect(called).toEventually(beTrue())
                 }
             }
+
+            context("AndesMessage Body Links") {
+                it("calls body link handler") {
+                    //Given
+                    let message = AndesMessage(frame: .zero)
+                    var tappedIndex: Int?
+
+                    message.body = "This is body message"
+
+                    let links = [
+                        AndesBodyLink(startIndex: 0, endIndex: 4),
+                        AndesBodyLink(startIndex: 5, endIndex: 10)
+                    ]
+                    let bodyLinks = AndesBodyLinks(links: links, listener: { index in
+                        tappedIndex = index
+                    })
+                    message.setBodyLinks(bodyLinks)
+
+                    //When
+                    _ = (message.contentView as! AndesMessageDefaultView).bodyTextView.delegate?.textView?(UITextView(), shouldInteractWith: URL(string: "1")!, in: NSRange(location: 0, length: 10), interaction: UITextItemInteraction(rawValue: 0)!)
+
+                    //Then
+                    expect(tappedIndex).toEventually(equal(1))
+                }
+            }
         }
     }
 }

--- a/LibraryComponents/Classes/AndesMessage/AndesMessage.swift
+++ b/LibraryComponents/Classes/AndesMessage/AndesMessage.swift
@@ -216,27 +216,3 @@ public extension AndesMessage {
         }
     }
 }
-
-public class AndesBodyLinks {
-    var links: [AndesBodyLink]
-    var listener: ((_ index: Int) -> Void)
-
-    public init(links: [AndesBodyLink], listener: @escaping ((_ index: Int) -> Void)) {
-        self.links = links
-        self.listener = listener
-    }
-}
-
-public class AndesBodyLink {
-    var startIndex: Int
-    var endIndex: Int
-
-    public init(startIndex: Int, endIndex: Int) {
-        self.startIndex = startIndex
-        self.endIndex = endIndex
-    }
-
-    func isValidRange(_ text: NSAttributedString) -> Bool {
-        return (startIndex >= 0 && endIndex >= 0 && startIndex <= endIndex && endIndex <= text.length)
-    }
-}

--- a/LibraryComponents/Classes/AndesMessage/AndesMessage.swift
+++ b/LibraryComponents/Classes/AndesMessage/AndesMessage.swift
@@ -235,4 +235,8 @@ public class AndesBodyLink {
         self.startIndex = startIndex
         self.endIndex = endIndex
     }
+
+    func isValidRange(_ text: NSAttributedString) -> Bool {
+        return (startIndex >= 0 && endIndex >= 0 && startIndex <= endIndex && endIndex <= text.length)
+    }
 }

--- a/LibraryComponents/Classes/AndesMessage/AndesMessage.swift
+++ b/LibraryComponents/Classes/AndesMessage/AndesMessage.swift
@@ -73,6 +73,8 @@ import UIKit
     // triggered when user presses secondary
     private var onSecondaryActionPressed: ((_ message: AndesMessage) -> Void)?
 
+    public var bodyLinks: AndesBodyLinks?
+
     required init?(coder: NSCoder) {
         super.init(coder: coder)
         setup()
@@ -159,6 +161,11 @@ import UIKit
         reDrawContentViewIfNeededThenUpdate()
     }
 
+    public func setBodyLinks(_ bodyLinks: AndesBodyLinks) {
+        self.bodyLinks = bodyLinks
+        reDrawContentViewIfNeededThenUpdate()
+    }
+
     /// Should return a view depending on which message variant is selected
     private func provideView() -> AndesMessageView {
         let config = AndesMessageViewConfigFactory.provideConfig(for: self)
@@ -207,5 +214,25 @@ public extension AndesMessage {
         get {
             return self.hierarchy.toString()
         }
+    }
+}
+
+public class AndesBodyLinks {
+    var links: [AndesBodyLink]
+    var listener: ((_ index: Int) -> Void)
+
+    public init(links: [AndesBodyLink], listener: @escaping ((_ index: Int) -> Void)) {
+        self.links = links
+        self.listener = listener
+    }
+}
+
+public class AndesBodyLink {
+    var startIndex: Int
+    var endIndex: Int
+
+    public init(startIndex: Int, endIndex: Int) {
+        self.startIndex = startIndex
+        self.endIndex = endIndex
     }
 }

--- a/LibraryComponents/Classes/AndesMessage/BodyLinks/AndesBodyLink.swift
+++ b/LibraryComponents/Classes/AndesMessage/BodyLinks/AndesBodyLink.swift
@@ -1,0 +1,20 @@
+//
+//  AndesBodyLink.swift
+//  AndesUI
+//
+//  Created by Marcelo Agustin Gil on 27/07/2020.
+//
+
+public class AndesBodyLink {
+    var startIndex: Int
+    var endIndex: Int
+
+    public init(startIndex: Int, endIndex: Int) {
+        self.startIndex = startIndex
+        self.endIndex = endIndex
+    }
+
+    func isValidRange(_ text: NSAttributedString) -> Bool {
+        return (startIndex >= 0 && endIndex >= 0 && startIndex <= endIndex && endIndex <= text.length)
+    }
+}

--- a/LibraryComponents/Classes/AndesMessage/BodyLinks/AndesBodyLinks.swift
+++ b/LibraryComponents/Classes/AndesMessage/BodyLinks/AndesBodyLinks.swift
@@ -1,0 +1,16 @@
+//
+//  AndesBodyLinks.swift
+//  AndesUI
+//
+//  Created by Marcelo Agustin Gil on 27/07/2020.
+//
+
+public class AndesBodyLinks {
+    var links: [AndesBodyLink]
+    var listener: ((_ index: Int) -> Void)
+
+    public init(links: [AndesBodyLink], listener: @escaping ((_ index: Int) -> Void)) {
+        self.links = links
+        self.listener = listener
+    }
+}

--- a/LibraryComponents/Classes/AndesMessage/Config/AndesMessageViewConfig.swift
+++ b/LibraryComponents/Classes/AndesMessage/Config/AndesMessageViewConfig.swift
@@ -30,8 +30,9 @@ internal struct AndesMessageViewConfig {
     var linkActionConfig: AndesButtonViewConfig?
 
     var bodyLinks: AndesBodyLinks?
+    var hierarchy: AndesMessageHierarchy?
 
-    init(backgroundColor: UIColor, pipeColor: UIColor, textColor: UIColor, titleText: String?, bodyText: String, icon: String?, iconBackgroundColor: UIColor, isDismissable: Bool, dismissIconColor: UIColor, bodyLinks: AndesBodyLinks?) {
+    init(backgroundColor: UIColor, pipeColor: UIColor, textColor: UIColor, titleText: String?, bodyText: String, icon: String?, iconBackgroundColor: UIColor, isDismissable: Bool, dismissIconColor: UIColor, bodyLinks: AndesBodyLinks?, hierarchy: AndesMessageHierarchy) {
         self.backgroundColor = backgroundColor
         self.pipeColor = pipeColor
 
@@ -47,6 +48,7 @@ internal struct AndesMessageViewConfig {
         self.dismissIconColor = dismissIconColor
 
         self.bodyLinks = bodyLinks
+        self.hierarchy = hierarchy
     }
 
     init() {

--- a/LibraryComponents/Classes/AndesMessage/Config/AndesMessageViewConfig.swift
+++ b/LibraryComponents/Classes/AndesMessage/Config/AndesMessageViewConfig.swift
@@ -29,7 +29,9 @@ internal struct AndesMessageViewConfig {
     var secondaryActionConfig: AndesButtonViewConfig?
     var linkActionConfig: AndesButtonViewConfig?
 
-    init(backgroundColor: UIColor, pipeColor: UIColor, textColor: UIColor, titleText: String?, bodyText: String, icon: String?, iconBackgroundColor: UIColor, isDismissable: Bool, dismissIconColor: UIColor) {
+    var bodyLinks: AndesBodyLinks?
+
+    init(backgroundColor: UIColor, pipeColor: UIColor, textColor: UIColor, titleText: String?, bodyText: String, icon: String?, iconBackgroundColor: UIColor, isDismissable: Bool, dismissIconColor: UIColor, bodyLinks: AndesBodyLinks?) {
         self.backgroundColor = backgroundColor
         self.pipeColor = pipeColor
 
@@ -43,6 +45,8 @@ internal struct AndesMessageViewConfig {
 
         self.iconBackgroundColor = iconBackgroundColor
         self.dismissIconColor = dismissIconColor
+
+        self.bodyLinks = bodyLinks
     }
 
     init() {

--- a/LibraryComponents/Classes/AndesMessage/Config/AndesMessageViewConfig.swift
+++ b/LibraryComponents/Classes/AndesMessage/Config/AndesMessageViewConfig.swift
@@ -30,9 +30,10 @@ internal struct AndesMessageViewConfig {
     var linkActionConfig: AndesButtonViewConfig?
 
     var bodyLinks: AndesBodyLinks?
-    var hierarchy: AndesMessageHierarchy?
+    var bodyLinkIsUnderline: Bool = false
+    var bodyLinkTextColor: UIColor = AndesStyleSheetManager.styleSheet.accentColor500
 
-    init(backgroundColor: UIColor, pipeColor: UIColor, textColor: UIColor, titleText: String?, bodyText: String, icon: String?, iconBackgroundColor: UIColor, isDismissable: Bool, dismissIconColor: UIColor, bodyLinks: AndesBodyLinks?, hierarchy: AndesMessageHierarchy) {
+    init(backgroundColor: UIColor, pipeColor: UIColor, textColor: UIColor, titleText: String?, bodyText: String, icon: String?, iconBackgroundColor: UIColor, isDismissable: Bool, dismissIconColor: UIColor, bodyLinks: AndesBodyLinks?, bodyLinkIsUnderline: Bool, bodyLinkTextColor: UIColor) {
         self.backgroundColor = backgroundColor
         self.pipeColor = pipeColor
 
@@ -48,7 +49,8 @@ internal struct AndesMessageViewConfig {
         self.dismissIconColor = dismissIconColor
 
         self.bodyLinks = bodyLinks
-        self.hierarchy = hierarchy
+        self.bodyLinkIsUnderline = bodyLinkIsUnderline
+        self.bodyLinkTextColor = bodyLinkTextColor
     }
 
     init() {

--- a/LibraryComponents/Classes/AndesMessage/Config/AndesMessageViewConfigFactory.swift
+++ b/LibraryComponents/Classes/AndesMessage/Config/AndesMessageViewConfigFactory.swift
@@ -11,7 +11,7 @@ internal class AndesMessageViewConfigFactory {
         let typeIns = AndesMessageTypeFactory.provide(message.type)
         let hierarchyIns = AndesMessageHierarchyFactory.provide(message.hierarchy, forType: typeIns)
 
-        var config = AndesMessageViewConfig(backgroundColor: hierarchyIns.backgroundColor, pipeColor: hierarchyIns.pipeColor, textColor: hierarchyIns.textColor, titleText: message.title, bodyText: message.body, icon: typeIns.icon, iconBackgroundColor: hierarchyIns.accentColor, isDismissable: message.isDismissable, dismissIconColor: hierarchyIns.textColor, bodyLinks: message.bodyLinks, hierarchy: message.hierarchy)
+        var config = AndesMessageViewConfig(backgroundColor: hierarchyIns.backgroundColor, pipeColor: hierarchyIns.pipeColor, textColor: hierarchyIns.textColor, titleText: message.title, bodyText: message.body, icon: typeIns.icon, iconBackgroundColor: hierarchyIns.accentColor, isDismissable: message.isDismissable, dismissIconColor: hierarchyIns.textColor, bodyLinks: message.bodyLinks, bodyLinkIsUnderline: hierarchyIns.bodyLinkIsUnderline, bodyLinkTextColor: hierarchyIns.bodyLinkTextColor)
 
         if let primaryText = message.primaryActionText, !primaryText.isEmpty {
             config.primaryActionConfig = AndesButtonViewConfigFactory.provide(hierarchy: hierarchyIns.primaryButtonHierarchy, size: AndesButtonSizeMedium(), text: primaryText, icon: nil)

--- a/LibraryComponents/Classes/AndesMessage/Config/AndesMessageViewConfigFactory.swift
+++ b/LibraryComponents/Classes/AndesMessage/Config/AndesMessageViewConfigFactory.swift
@@ -11,7 +11,7 @@ internal class AndesMessageViewConfigFactory {
         let typeIns = AndesMessageTypeFactory.provide(message.type)
         let hierarchyIns = AndesMessageHierarchyFactory.provide(message.hierarchy, forType: typeIns)
 
-        var config = AndesMessageViewConfig(backgroundColor: hierarchyIns.backgroundColor, pipeColor: hierarchyIns.pipeColor, textColor: hierarchyIns.textColor, titleText: message.title, bodyText: message.body, icon: typeIns.icon, iconBackgroundColor: hierarchyIns.accentColor, isDismissable: message.isDismissable, dismissIconColor: hierarchyIns.textColor, bodyLinks: message.bodyLinks)
+        var config = AndesMessageViewConfig(backgroundColor: hierarchyIns.backgroundColor, pipeColor: hierarchyIns.pipeColor, textColor: hierarchyIns.textColor, titleText: message.title, bodyText: message.body, icon: typeIns.icon, iconBackgroundColor: hierarchyIns.accentColor, isDismissable: message.isDismissable, dismissIconColor: hierarchyIns.textColor, bodyLinks: message.bodyLinks, hierarchy: message.hierarchy)
 
         if let primaryText = message.primaryActionText, !primaryText.isEmpty {
             config.primaryActionConfig = AndesButtonViewConfigFactory.provide(hierarchy: hierarchyIns.primaryButtonHierarchy, size: AndesButtonSizeMedium(), text: primaryText, icon: nil)

--- a/LibraryComponents/Classes/AndesMessage/Config/AndesMessageViewConfigFactory.swift
+++ b/LibraryComponents/Classes/AndesMessage/Config/AndesMessageViewConfigFactory.swift
@@ -11,7 +11,7 @@ internal class AndesMessageViewConfigFactory {
         let typeIns = AndesMessageTypeFactory.provide(message.type)
         let hierarchyIns = AndesMessageHierarchyFactory.provide(message.hierarchy, forType: typeIns)
 
-        var config = AndesMessageViewConfig(backgroundColor: hierarchyIns.backgroundColor, pipeColor: hierarchyIns.pipeColor, textColor: hierarchyIns.textColor, titleText: message.title, bodyText: message.body, icon: typeIns.icon, iconBackgroundColor: hierarchyIns.accentColor, isDismissable: message.isDismissable, dismissIconColor: hierarchyIns.textColor)
+        var config = AndesMessageViewConfig(backgroundColor: hierarchyIns.backgroundColor, pipeColor: hierarchyIns.pipeColor, textColor: hierarchyIns.textColor, titleText: message.title, bodyText: message.body, icon: typeIns.icon, iconBackgroundColor: hierarchyIns.accentColor, isDismissable: message.isDismissable, dismissIconColor: hierarchyIns.textColor, bodyLinks: message.bodyLinks)
 
         if let primaryText = message.primaryActionText, !primaryText.isEmpty {
             config.primaryActionConfig = AndesButtonViewConfigFactory.provide(hierarchy: hierarchyIns.primaryButtonHierarchy, size: AndesButtonSizeMedium(), text: primaryText, icon: nil)

--- a/LibraryComponents/Classes/AndesMessage/Hierarchy/AndesMessageHierarchyLoud.swift
+++ b/LibraryComponents/Classes/AndesMessage/Hierarchy/AndesMessageHierarchyLoud.swift
@@ -23,6 +23,10 @@ struct AndesMessageHierarchyLoud: AndesMessageHierarchyProtocol {
 
     var accentColor: UIColor
 
+    var bodyLinkIsUnderline: Bool
+
+    var bodyLinkTextColor: UIColor
+
     init(type: AndesMessageTypeProtocol) {
         backgroundColor = type.primaryColor
         pipeColor = type.primaryColor
@@ -30,5 +34,7 @@ struct AndesMessageHierarchyLoud: AndesMessageHierarchyProtocol {
         primaryButtonHierarchy = PrimaryMessageActionButtonHierarchy(backgroundColor: type.secondaryColor, pressedColor: type.primaryButtonPressedColor)
         secondaryButtonHierarchy = SecondaryMessageActionButtonHierarchy(textColor: textColor, pressedColor: type.secondaryButtonPressedColor)
         linkButtonHierarchy = LinkMessageActionButtonHierarchy(textColor: textColor, pressedColor: type.linkButtonPressedColor)
+        bodyLinkIsUnderline = true
+        bodyLinkTextColor = textColor
     }
 }

--- a/LibraryComponents/Classes/AndesMessage/Hierarchy/AndesMessageHierarchyProtocol.swift
+++ b/LibraryComponents/Classes/AndesMessage/Hierarchy/AndesMessageHierarchyProtocol.swift
@@ -16,4 +16,6 @@ internal protocol AndesMessageHierarchyProtocol {
     var primaryButtonHierarchy: AndesButtonHierarchyProtocol { get }
     var secondaryButtonHierarchy: AndesButtonHierarchyProtocol { get }
     var linkButtonHierarchy: AndesButtonHierarchyProtocol { get }
+    var bodyLinkIsUnderline: Bool { get }
+    var bodyLinkTextColor: UIColor { get }
 }

--- a/LibraryComponents/Classes/AndesMessage/Hierarchy/AndesMessageHierarchyQuiet.swift
+++ b/LibraryComponents/Classes/AndesMessage/Hierarchy/AndesMessageHierarchyQuiet.swift
@@ -23,6 +23,10 @@ struct AndesMessageHierarchyQuiet: AndesMessageHierarchyProtocol {
 
     var accentColor: UIColor
 
+    var bodyLinkIsUnderline: Bool
+
+    var bodyLinkTextColor: UIColor
+
     init(type: AndesMessageTypeProtocol) {
         pipeColor = type.primaryColor
         accentColor = type.primaryColor
@@ -31,5 +35,7 @@ struct AndesMessageHierarchyQuiet: AndesMessageHierarchyProtocol {
         linkButtonHierarchy = LinkMessageActionButtonHierarchy(textColor: AndesStyleSheetManager.styleSheet.accentColor500,
                                                                pressedColor: type.linkButtonPressedColor
         )
+        bodyLinkIsUnderline = false
+        bodyLinkTextColor = AndesStyleSheetManager.styleSheet.accentColor500
     }
 }

--- a/LibraryComponents/Classes/AndesMessage/View/AndesMessageAbstractView.swift
+++ b/LibraryComponents/Classes/AndesMessage/View/AndesMessageAbstractView.swift
@@ -7,12 +7,12 @@
 
 import UIKit
 
-class AndesMessageAbstractView: UIView, AndesMessageView {
+class AndesMessageAbstractView: UIView, AndesMessageView, UITextViewDelegate {
     weak var delegate: AndesMessageViewDelegate?
 
     @IBOutlet var messageView: UIView!
     @IBOutlet weak var titleLabel: UILabel!
-    @IBOutlet weak var bodyLabel: UILabel!
+    @IBOutlet weak var bodyTextView: UITextView!
     @IBOutlet weak var iconView: UIImageView!
     @IBOutlet weak var iconContainerView: UIView!
     @IBOutlet weak var leftPipeView: UIView!
@@ -71,8 +71,10 @@ class AndesMessageAbstractView: UIView, AndesMessageView {
         self.backgroundColor = config.backgroundColor
         self.leftPipeView.backgroundColor = config.pipeColor
 
-        self.bodyLabel.setAndesStyle(style: config.bodyStyle)
-        self.bodyLabel.text = config.bodyText
+        self.bodyTextView.setAndesStyle(style: config.bodyStyle)
+        self.bodyTextView.attributedText = getBodyText(style: config.bodyStyle)
+        self.bodyTextView.delegate = self
+        self.bodyTextView.isScrollEnabled = false
 
         self.iconView.tintColor = config.iconColor
         if let icon = config.icon {
@@ -104,5 +106,33 @@ class AndesMessageAbstractView: UIView, AndesMessageView {
             self.titleToSafeAreaConstraint.priority = .init(rawValue: 999)
             self.dismissButton.isHidden = true
         }
+    }
+
+    func getBodyText(style: AndesFontStyle) -> NSAttributedString {
+        let attributedString = NSMutableAttributedString(string: config.bodyText ?? "")
+
+        let allRange = NSRange(location: 0, length: attributedString.length)
+
+        attributedString.addAttribute(.foregroundColor, value: style.textColor, range: allRange)
+
+        let paragraphStyle = NSMutableParagraphStyle()
+        paragraphStyle.lineSpacing = style.lineSpacing
+        attributedString.addAttribute(.paragraphStyle, value: paragraphStyle, range: allRange)
+
+        if let bodyLinks = config.bodyLinks {
+            for (index, link) in bodyLinks.links.enumerated() {
+                let range = NSRange(location: link.startIndex, length: link.endIndex - link.startIndex)
+                attributedString.addAttribute(.link, value: String(describing: index), range: range)
+                attributedString.addAttribute(.underlineStyle, value: NSUnderlineStyle.single.rawValue, range: range)
+            }
+        }
+
+        return attributedString
+    }
+
+    func textView(_ textView: UITextView, shouldInteractWith URL: URL, in characterRange: NSRange, interaction: UITextItemInteraction) -> Bool {
+        let index = Int(String(describing: URL)) ?? 0
+        config.bodyLinks?.listener(index)
+        return false
     }
 }

--- a/LibraryComponents/Classes/AndesMessage/View/AndesMessageAbstractView.swift
+++ b/LibraryComponents/Classes/AndesMessage/View/AndesMessageAbstractView.swift
@@ -120,9 +120,13 @@ class AndesMessageAbstractView: UIView, AndesMessageView, UITextViewDelegate {
 
         if let bodyLinks = config.bodyLinks {
             for (index, link) in bodyLinks.links.enumerated() {
-                let range = NSRange(location: link.startIndex, length: link.endIndex - link.startIndex)
-                attributedString.addAttribute(.link, value: String(describing: index), range: range)
-                attributedString.addAttribute(.underlineStyle, value: NSUnderlineStyle.single.rawValue, range: range)
+                if link.isValidRange(attributedString) {
+                    let range = NSRange(location: link.startIndex, length: link.endIndex - link.startIndex)
+                    attributedString.addAttribute(.link, value: String(describing: index), range: range)
+                    attributedString.addAttribute(.underlineStyle, value: NSUnderlineStyle.single.rawValue, range: range)
+                } else {
+                    print("Body link range incorrect: \(link.startIndex), \(link.endIndex)")
+                }
             }
         }
 

--- a/LibraryComponents/Classes/AndesMessage/View/AndesMessageAbstractView.swift
+++ b/LibraryComponents/Classes/AndesMessage/View/AndesMessageAbstractView.swift
@@ -73,7 +73,7 @@ class AndesMessageAbstractView: UIView, AndesMessageView, UITextViewDelegate {
 
         self.bodyTextView.setAndesStyle(style: config.bodyStyle)
         self.bodyTextView.attributedText = getBodyText(style: config.bodyStyle)
-        self.bodyTextView.linkTextAttributes = [NSAttributedString.Key.foregroundColor: getColorByHierarchy()]
+        self.bodyTextView.linkTextAttributes = [NSAttributedString.Key.foregroundColor: config.bodyLinkTextColor]
         self.bodyTextView.delegate = self
 
         self.iconView.tintColor = config.iconColor
@@ -125,8 +125,7 @@ class AndesMessageAbstractView: UIView, AndesMessageView, UITextViewDelegate {
                     let range = NSRange(location: link.startIndex, length: link.endIndex - link.startIndex)
                     attributedString.addAttribute(.link, value: String(describing: index), range: range)
 
-                    //AndesMessageHierarchy is loud should be underline
-                    if config.hierarchy == AndesMessageHierarchy.loud {
+                    if config.bodyLinkIsUnderline {
                         attributedString.addAttribute(.underlineStyle, value: NSUnderlineStyle.single.rawValue, range: range)
                     }
                 }
@@ -134,15 +133,6 @@ class AndesMessageAbstractView: UIView, AndesMessageView, UITextViewDelegate {
         }
 
         return attributedString
-    }
-
-    func getColorByHierarchy() -> UIColor {
-        if config.hierarchy == AndesMessageHierarchy.loud {
-            return config.bodyStyle.textColor
-        } else {
-            #warning("What color should apply here?")
-            return config.pipeColor
-        }
     }
 
     func textView(_ textView: UITextView, shouldInteractWith URL: URL, in characterRange: NSRange, interaction: UITextItemInteraction) -> Bool {

--- a/LibraryComponents/Classes/AndesMessage/View/AndesMessageAbstractView.swift
+++ b/LibraryComponents/Classes/AndesMessage/View/AndesMessageAbstractView.swift
@@ -124,8 +124,6 @@ class AndesMessageAbstractView: UIView, AndesMessageView, UITextViewDelegate {
                     let range = NSRange(location: link.startIndex, length: link.endIndex - link.startIndex)
                     attributedString.addAttribute(.link, value: String(describing: index), range: range)
                     attributedString.addAttribute(.underlineStyle, value: NSUnderlineStyle.single.rawValue, range: range)
-                } else {
-                    print("Body link range incorrect: \(link.startIndex), \(link.endIndex)")
                 }
             }
         }

--- a/LibraryComponents/Classes/AndesMessage/View/AndesMessageAbstractView.swift
+++ b/LibraryComponents/Classes/AndesMessage/View/AndesMessageAbstractView.swift
@@ -74,7 +74,6 @@ class AndesMessageAbstractView: UIView, AndesMessageView, UITextViewDelegate {
         self.bodyTextView.setAndesStyle(style: config.bodyStyle)
         self.bodyTextView.attributedText = getBodyText(style: config.bodyStyle)
         self.bodyTextView.delegate = self
-        self.bodyTextView.isScrollEnabled = false
 
         self.iconView.tintColor = config.iconColor
         if let icon = config.icon {

--- a/LibraryComponents/Classes/AndesMessage/View/AndesMessageAbstractView.swift
+++ b/LibraryComponents/Classes/AndesMessage/View/AndesMessageAbstractView.swift
@@ -73,6 +73,7 @@ class AndesMessageAbstractView: UIView, AndesMessageView, UITextViewDelegate {
 
         self.bodyTextView.setAndesStyle(style: config.bodyStyle)
         self.bodyTextView.attributedText = getBodyText(style: config.bodyStyle)
+        self.bodyTextView.linkTextAttributes = [NSAttributedString.Key.foregroundColor: getColorByHierarchy()]
         self.bodyTextView.delegate = self
 
         self.iconView.tintColor = config.iconColor
@@ -123,12 +124,25 @@ class AndesMessageAbstractView: UIView, AndesMessageView, UITextViewDelegate {
                 if link.isValidRange(attributedString) {
                     let range = NSRange(location: link.startIndex, length: link.endIndex - link.startIndex)
                     attributedString.addAttribute(.link, value: String(describing: index), range: range)
-                    attributedString.addAttribute(.underlineStyle, value: NSUnderlineStyle.single.rawValue, range: range)
+
+                    //AndesMessageHierarchy is loud should be underline
+                    if config.hierarchy == AndesMessageHierarchy.loud {
+                        attributedString.addAttribute(.underlineStyle, value: NSUnderlineStyle.single.rawValue, range: range)
+                    }
                 }
             }
         }
 
         return attributedString
+    }
+
+    func getColorByHierarchy() -> UIColor {
+        if config.hierarchy == AndesMessageHierarchy.loud {
+            return config.bodyStyle.textColor
+        } else {
+            #warning("What color should apply here?")
+            return config.pipeColor
+        }
     }
 
     func textView(_ textView: UITextView, shouldInteractWith URL: URL, in characterRange: NSRange, interaction: UITextItemInteraction) -> Bool {

--- a/LibraryComponents/Classes/AndesMessage/View/Default/AndesMessageDefaultView.xib
+++ b/LibraryComponents/Classes/AndesMessage/View/Default/AndesMessageDefaultView.xib
@@ -77,7 +77,7 @@
                             <nil key="textColor"/>
                             <nil key="highlightedColor"/>
                         </label>
-                        <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" editable="NO" text="body" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="HuK-Ws-ZkI">
+                        <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" bounces="NO" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" bouncesZoom="NO" editable="NO" text="body" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="HuK-Ws-ZkI">
                             <rect key="frame" x="0.0" y="25.5" width="331" height="110"/>
                             <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             <accessibility key="accessibilityConfiguration">

--- a/LibraryComponents/Classes/AndesMessage/View/Default/AndesMessageDefaultView.xib
+++ b/LibraryComponents/Classes/AndesMessage/View/Default/AndesMessageDefaultView.xib
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16096" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15705" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15706"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="AndesMessageDefaultView" customModule="AndesUI">
             <connections>
-                <outlet property="bodyLabel" destination="Ka6-MC-Ijq" id="8av-3w-jlS"/>
+                <outlet property="bodyTextView" destination="HuK-Ws-ZkI" id="dDv-pl-UDg"/>
                 <outlet property="dismissButton" destination="xSe-Le-1pW" id="cYn-eo-qgB"/>
                 <outlet property="iconContainerView" destination="CsU-Ah-Mc0" id="Jga-UN-maA"/>
                 <outlet property="iconView" destination="osp-E1-bQZ" id="EDe-uX-9p8"/>
@@ -77,12 +77,16 @@
                             <nil key="textColor"/>
                             <nil key="highlightedColor"/>
                         </label>
-                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="249" text="body" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ka6-MC-Ijq">
+                        <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" editable="NO" text="body" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="HuK-Ws-ZkI">
                             <rect key="frame" x="0.0" y="25.5" width="331" height="110"/>
+                            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                            <accessibility key="accessibilityConfiguration">
+                                <accessibilityTraits key="traits" staticText="YES"/>
+                            </accessibility>
+                            <color key="textColor" systemColor="labelColor" cocoaTouchSystemColor="darkTextColor"/>
                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                            <nil key="textColor"/>
-                            <nil key="highlightedColor"/>
-                        </label>
+                            <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
+                        </textView>
                     </subviews>
                 </stackView>
             </subviews>

--- a/LibraryComponents/Classes/AndesMessage/View/WithActions/AndesMessageWithActionsView.xib
+++ b/LibraryComponents/Classes/AndesMessage/View/WithActions/AndesMessageWithActionsView.xib
@@ -80,7 +80,7 @@
                             <nil key="textColor"/>
                             <nil key="highlightedColor"/>
                         </label>
-                        <textView opaque="NO" multipleTouchEnabled="YES" contentMode="left" editable="NO" text="body" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="d73-Ie-8ZP">
+                        <textView opaque="NO" multipleTouchEnabled="YES" contentMode="left" bounces="NO" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" bouncesZoom="NO" editable="NO" text="body" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="d73-Ie-8ZP">
                             <rect key="frame" x="0.0" y="25.5" width="194" height="42"/>
                             <accessibility key="accessibilityConfiguration">
                                 <accessibilityTraits key="traits" staticText="YES"/>

--- a/LibraryComponents/Classes/AndesMessage/View/WithActions/AndesMessageWithActionsView.xib
+++ b/LibraryComponents/Classes/AndesMessage/View/WithActions/AndesMessageWithActionsView.xib
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15400" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15705" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15404"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15706"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="AndesMessageWithActionsView" customModule="AndesUI">
             <connections>
-                <outlet property="bodyLabel" destination="58O-gd-Aup" id="ohB-Bn-CwC"/>
+                <outlet property="bodyTextView" destination="d73-Ie-8ZP" id="Exd-N6-Lxd"/>
                 <outlet property="dismissButton" destination="AH2-H9-2Dt" id="Xox-4a-AFE"/>
                 <outlet property="iconContainerView" destination="Mbf-ep-nbj" id="yea-3i-LtJ"/>
                 <outlet property="iconView" destination="KSx-w5-sbK" id="Qwx-DJ-uKG"/>
@@ -72,7 +72,7 @@
                     </userDefinedRuntimeAttributes>
                 </view>
                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="CPr-he-XXd">
-                    <rect key="frame" x="48" y="15.5" width="194" height="46"/>
+                    <rect key="frame" x="48" y="15.5" width="194" height="67.5"/>
                     <subviews>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="KcW-WK-QzY">
                             <rect key="frame" x="0.0" y="0.0" width="194" height="20.5"/>
@@ -80,16 +80,19 @@
                             <nil key="textColor"/>
                             <nil key="highlightedColor"/>
                         </label>
-                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="249" text="body" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="58O-gd-Aup">
-                            <rect key="frame" x="0.0" y="25.5" width="194" height="20.5"/>
+                        <textView opaque="NO" multipleTouchEnabled="YES" contentMode="left" editable="NO" text="body" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="d73-Ie-8ZP">
+                            <rect key="frame" x="0.0" y="25.5" width="194" height="42"/>
+                            <accessibility key="accessibilityConfiguration">
+                                <accessibilityTraits key="traits" staticText="YES"/>
+                            </accessibility>
+                            <color key="textColor" systemColor="labelColor" cocoaTouchSystemColor="darkTextColor"/>
                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                            <nil key="textColor"/>
-                            <nil key="highlightedColor"/>
-                        </label>
+                            <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
+                        </textView>
                     </subviews>
                 </stackView>
                 <view contentMode="scaleToFill" placeholderIntrinsicWidth="50" placeholderIntrinsicHeight="21.5" translatesAutoresizingMaskIntoConstraints="NO" id="HbG-CF-Oqd" customClass="AndesButton" customModule="AndesUI">
-                    <rect key="frame" x="48" y="77.5" width="50" height="21.5"/>
+                    <rect key="frame" x="48" y="99" width="50" height="0.0"/>
                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     <accessibility key="accessibilityConfiguration" identifier="andesMessagePrimaryAction"/>
                     <connections>
@@ -97,7 +100,7 @@
                     </connections>
                 </view>
                 <view contentMode="scaleToFill" verticalHuggingPriority="249" horizontalCompressionResistancePriority="749" placeholderIntrinsicWidth="322" placeholderIntrinsicHeight="21.5" translatesAutoresizingMaskIntoConstraints="NO" id="UDP-xQ-Pdx" customClass="AndesButton" customModule="AndesUI">
-                    <rect key="frame" x="114" y="77.5" width="164" height="21.5"/>
+                    <rect key="frame" x="114" y="88.5" width="164" height="21.5"/>
                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     <accessibility key="accessibilityConfiguration" identifier="andesMessageSecondaryAction"/>
                     <connections>

--- a/LibraryComponents/Classes/Utils/Additions/UITextView+Additions.swift
+++ b/LibraryComponents/Classes/Utils/Additions/UITextView+Additions.swift
@@ -1,0 +1,14 @@
+//
+//  UITextView+Additions.swift
+//  AndesUI
+//
+//  Created by Marcelo Agustin Gil on 26/07/2020.
+//
+
+import UIKit
+@objc public extension UITextView {
+    func setAndesStyle(style: AndesFontStyle) {
+        self.font = style.font
+        self.linkTextAttributes = [NSAttributedString.Key.foregroundColor: style.textColor]
+    }
+}

--- a/LibraryComponents/Classes/Utils/Additions/UITextView+Additions.swift
+++ b/LibraryComponents/Classes/Utils/Additions/UITextView+Additions.swift
@@ -9,7 +9,6 @@ import UIKit
 @objc public extension UITextView {
     func setAndesStyle(style: AndesFontStyle) {
         self.font = style.font
-        self.linkTextAttributes = [NSAttributedString.Key.foregroundColor: style.textColor]
         self.textContainerInset = .zero
         self.textContainer.lineFragmentPadding = 0
         self.isScrollEnabled = false

--- a/LibraryComponents/Classes/Utils/Additions/UITextView+Additions.swift
+++ b/LibraryComponents/Classes/Utils/Additions/UITextView+Additions.swift
@@ -10,5 +10,8 @@ import UIKit
     func setAndesStyle(style: AndesFontStyle) {
         self.font = style.font
         self.linkTextAttributes = [NSAttributedString.Key.foregroundColor: style.textColor]
+        self.textContainerInset = .zero
+        self.textContainer.lineFragmentPadding = 0
+        self.isScrollEnabled = false
     }
 }

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,9 +1,9 @@
 PODS:
-  - AndesUI (3.4.0):
-    - AndesUI/Core (= 3.4.0)
-  - AndesUI/Core (3.4.0):
+  - AndesUI (3.7.0):
+    - AndesUI/Core (= 3.7.0)
+  - AndesUI/Core (3.7.0):
     - AndesUI/LocalIcons
-  - AndesUI/LocalIcons (3.4.0)
+  - AndesUI/LocalIcons (3.7.0)
   - IQKeyboardManagerSwift (6.3.0)
   - Nimble (7.3.4)
   - Quick (1.2.0)
@@ -25,7 +25,7 @@ EXTERNAL SOURCES:
     :path: "./"
 
 SPEC CHECKSUMS:
-  AndesUI: 697402b5c96c9d1a5b5f6517cc7ec61b816158dc
+  AndesUI: 90f86d3adbbc12dab98db9da36d32ad890b341bf
   IQKeyboardManagerSwift: a8228c257614af98743b4cd8584637025f36358f
   Nimble: 051e3d8912d40138fa5591c78594f95fb172af37
   Quick: 58d203b1c5e27fff7229c4c1ae445ad7069a7a08


### PR DESCRIPTION
## Description
Permite agregar múltiples links en el body del AndesMessage

## Affected component
AndesMessage

## Screenshots / GIFs
<img width="308" alt="Captura de Pantalla 2020-07-29 a la(s) 18 50 02" src="https://user-images.githubusercontent.com/47793297/88857303-68ccb080-d1cc-11ea-81fb-200fd3e90d5e.png">
<img width="309" alt="Captura de Pantalla 2020-07-29 a la(s) 18 50 16" src="https://user-images.githubusercontent.com/47793297/88857309-69fddd80-d1cc-11ea-8b35-52dd79f604dc.png">

## Checks
Are you sure you followed all those steps? If so, repeat after me "I solemnly swear that ...":
   - [x ] I have coded an example inside the Demo App,
   - [x ] I have added proper tests,
   - [x ] I have modified the Changelog.md file,
   - [x ] I have updated GitHub wiki,
   - [ ] I have the explicit approval of one or more members of the UX Team,
   - [ ] I have checked that this code is ObjC compliant.
   - [ ] I have checked that all the new public enums conform to AndesEnumStringConvertible.
## Change type
This is easy, let us know what this code is about:
   - [ ] This code adds a new component
   - [ x] This code includes improvements to an existent component
   - [ ] This code improves or modifies ONLY the Demo App.
