### PR TITLE
AndesCoachmark change for objc supporting

### DIFF
--- a/Example/AndesUI.xcodeproj/project.pbxproj
+++ b/Example/AndesUI.xcodeproj/project.pbxproj
@@ -39,6 +39,8 @@
 		6D2152F3241C080C001CEA8D /* TextFieldObjCViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 6D2152F2241C080C001CEA8D /* TextFieldObjCViewController.m */; };
 		6D2152F9241C1210001CEA8D /* TextFieldViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 6D2152F8241C1210001CEA8D /* TextFieldViewController.xib */; };
 		6DBB66002436423200FA9581 /* AndesTextFieldTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DBB65FF2436423200FA9581 /* AndesTextFieldTests.swift */; };
+		8082FA3E24FEC62A00E97F1A /* CoachmarkObjCViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 8082FA3C24FEC62A00E97F1A /* CoachmarkObjCViewController.m */; };
+		8082FA3F24FEC62A00E97F1A /* CoachmarkObjCViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 8082FA3D24FEC62A00E97F1A /* CoachmarkObjCViewController.xib */; };
 		80B22F1924DC5B9900FE9197 /* CoachmarkRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80B22F1824DC5B9900FE9197 /* CoachmarkRouter.swift */; };
 		80B22F1C24DC5C3700FE9197 /* CoachmarkViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80B22F1A24DC5C3700FE9197 /* CoachmarkViewController.swift */; };
 		80B22F1D24DC5C3700FE9197 /* CoachmarkViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 80B22F1B24DC5C3700FE9197 /* CoachmarkViewController.xib */; };
@@ -192,6 +194,9 @@
 		6E64FFA0A9C64C1FB0EA4215 /* Pods-AndesUI-demoapp.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AndesUI-demoapp.release.xcconfig"; path = "Target Support Files/Pods-AndesUI-demoapp/Pods-AndesUI-demoapp.release.xcconfig"; sourceTree = "<group>"; };
 		705E1889E591A1D6D1E0B47E /* Pods-AndesUI-demoapp.mds.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AndesUI-demoapp.mds.xcconfig"; path = "Target Support Files/Pods-AndesUI-demoapp/Pods-AndesUI-demoapp.mds.xcconfig"; sourceTree = "<group>"; };
 		748830979405998C25BF67E4 /* Pods_AndesUI_demoapp.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_AndesUI_demoapp.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		8082FA3B24FEC62A00E97F1A /* CoachmarkObjCViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CoachmarkObjCViewController.h; sourceTree = "<group>"; };
+		8082FA3C24FEC62A00E97F1A /* CoachmarkObjCViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CoachmarkObjCViewController.m; sourceTree = "<group>"; };
+		8082FA3D24FEC62A00E97F1A /* CoachmarkObjCViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = CoachmarkObjCViewController.xib; sourceTree = "<group>"; };
 		80B22F1824DC5B9900FE9197 /* CoachmarkRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoachmarkRouter.swift; sourceTree = "<group>"; };
 		80B22F1A24DC5C3700FE9197 /* CoachmarkViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoachmarkViewController.swift; sourceTree = "<group>"; };
 		80B22F1B24DC5C3700FE9197 /* CoachmarkViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = CoachmarkViewController.xib; sourceTree = "<group>"; };
@@ -607,6 +612,9 @@
 			children = (
 				80B22F1A24DC5C3700FE9197 /* CoachmarkViewController.swift */,
 				80B22F1B24DC5C3700FE9197 /* CoachmarkViewController.xib */,
+				8082FA3B24FEC62A00E97F1A /* CoachmarkObjCViewController.h */,
+				8082FA3C24FEC62A00E97F1A /* CoachmarkObjCViewController.m */,
+				8082FA3D24FEC62A00E97F1A /* CoachmarkObjCViewController.xib */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -970,6 +978,7 @@
 				9CE112DD23CE58910017B770 /* MessageViewController.xib in Resources */,
 				F899354824A0EE22004BC82D /* CheckboxObjCViewController.xib in Resources */,
 				F8C3694F24A62E9D00B93DAC /* AndesCheckboxInitViewController.xib in Resources */,
+				8082FA3F24FEC62A00E97F1A /* CoachmarkObjCViewController.xib in Resources */,
 				F8249D0A24ABCAC8002A6456 /* AndesRadioButtonViewController.xib in Resources */,
 				8634C9E924AB774700DB7B9F /* SnackbarObjCViewController.xib in Resources */,
 				9C2FFC6B23EDB1A50016292E /* whats_new.html in Resources */,
@@ -1129,6 +1138,7 @@
 				F830F883249400020043D5AF /* CheckboxRouter.swift in Sources */,
 				86D656B5248FF79500E62C1E /* AndesDemoColor.swift in Sources */,
 				6D2152F3241C080C001CEA8D /* TextFieldObjCViewController.m in Sources */,
+				8082FA3E24FEC62A00E97F1A /* CoachmarkObjCViewController.m in Sources */,
 				9CD1072B23F1E7AB0081232D /* MessagesRouter.swift in Sources */,
 				80B22F1924DC5B9900FE9197 /* CoachmarkRouter.swift in Sources */,
 				86A1E30C24815CBA00B59D1D /* TagViewController.swift in Sources */,

--- a/Example/AndesUI/AndesUI-demoapp-Bridging-Header.h
+++ b/Example/AndesUI/AndesUI-demoapp-Bridging-Header.h
@@ -13,3 +13,4 @@
 #import "RadioButtonObjCViewController.h"
 #import "CardObjCViewController.h"
 #import "ThumbnailObjCViewController.h"
+#import "CoachmarkObjCViewController.h"

--- a/Example/AndesUI/Coachmark/Routers/CoachmarkRouter.swift
+++ b/Example/AndesUI/Coachmark/Routers/CoachmarkRouter.swift
@@ -13,12 +13,13 @@ protocol CoachmarkRouter: NSObject {
 }
 
 class CoachmarkAppRouter: NSObject {
-    var view: CoachmarkViewController!
+    var view: AndesShowcasePageViewController!
 }
 
 extension CoachmarkAppRouter: CoachmarkRouter {
     func route(from: UIViewController) {
-        view = CoachmarkViewController()
+        view = AndesShowcasePageViewController(controllers: [CoachmarkViewController(), CoachmarkObjCViewController()])
+        view.title = "AndesCoachmark"
         from.navigationController?.pushViewController(view, animated: true)
     }
 }

--- a/Example/AndesUI/Coachmark/Views/CoachmarkObjCViewController.h
+++ b/Example/AndesUI/Coachmark/Views/CoachmarkObjCViewController.h
@@ -1,0 +1,20 @@
+//
+//  CoachmarkObjCViewController.h
+//  AndesUI-demoapp
+//
+//  Created by JONATHAN DANIEL BANDONI on 01/09/2020.
+//  Copyright © 2020 MercadoLibre. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+#import <AndesUI-Swift.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface CoachmarkObjCViewController : UIViewController
+
+@property (nonatomic) AndesCoachMarkView *coachmark;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Example/AndesUI/Coachmark/Views/CoachmarkObjCViewController.m
+++ b/Example/AndesUI/Coachmark/Views/CoachmarkObjCViewController.m
@@ -1,0 +1,47 @@
+//
+//  CoachmarkObjCViewController.m
+//  AndesUI-demoapp
+//
+//  Created by JONATHAN DANIEL BANDONI on 01/09/2020.
+//  Copyright © 2020 MercadoLibre. All rights reserved.
+//
+
+#import "CoachmarkObjCViewController.h"
+
+@interface CoachmarkObjCViewController ()
+@property (weak, nonatomic) IBOutlet UIView *upView;
+@property (weak, nonatomic) IBOutlet UIView *leftView;
+@property (weak, nonatomic) IBOutlet UIView *rightView;
+@property (weak, nonatomic) IBOutlet UIView *downView;
+@property (weak, nonatomic) IBOutlet UIScrollView *scrollView;
+
+@end
+
+@implementation CoachmarkObjCViewController
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+    [self setupCoachmark];
+}
+
+- (void)viewDidAppear:(BOOL)animated {
+    [super viewDidAppear:animated];
+    [_coachmark start];
+}
+
+- (void)setupCoachmark {
+    AndesCoachMarkStepEntity *upStep = [[AndesCoachMarkStepEntity alloc] initWithTitle:@"Primer paso" description:@"Se dibuja la flecha arriba a la izquierda." view:_upView style:HighlightStyleRectangle nextText:@"Siguiente"];
+    
+    AndesCoachMarkStepEntity *leftStep = [[AndesCoachMarkStepEntity alloc] initWithTitle:@"Segundo paso" description:@"Se dibuja la flecha abajo a la izquierda." view:_leftView style:HighlightStyleRectangle nextText:@"Siguiente"];
+    
+    AndesCoachMarkStepEntity *rightStep = [[AndesCoachMarkStepEntity alloc] initWithTitle:@"Tercer paso" description:@"Se dibuja la flecha arriba a la derecha." view:_rightView style:HighlightStyleRectangle nextText:@"Siguiente"];
+    
+    AndesCoachMarkStepEntity *downStep = [[AndesCoachMarkStepEntity alloc] initWithTitle:@"Cuarto paso" description:@"Se dibuja la flecha abajo a la derecha." view:_downView style:HighlightStyleRectangle nextText:@"Siguiente"];
+    
+    AndesCoachMarkEntity *model = [[AndesCoachMarkEntity alloc] initWithSteps:@[upStep,leftStep,rightStep,downStep] scrollView:_scrollView completionHandler:NULL];
+    
+    _coachmark = [[AndesCoachMarkView alloc] initWithModel:model];
+}
+
+
+@end

--- a/Example/AndesUI/Coachmark/Views/CoachmarkObjCViewController.xib
+++ b/Example/AndesUI/Coachmark/Views/CoachmarkObjCViewController.xib
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15400" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15404"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="CoachmarkObjCViewController">
+            <connections>
+                <outlet property="UpView" destination="qeh-ED-PxH" id="ErV-Yx-rlu"/>
+                <outlet property="downView" destination="pSZ-St-b39" id="Y2Z-4O-usU"/>
+                <outlet property="leftView" destination="0gv-mi-aQc" id="may-Y8-Yop"/>
+                <outlet property="rightView" destination="bba-Ol-2un" id="xEf-3R-Pve"/>
+                <outlet property="scrollView" destination="5Vn-Ge-dJG" id="jqm-0U-3xe"/>
+                <outlet property="upView" destination="qeh-ED-PxH" id="xhR-1h-X7M"/>
+                <outlet property="view" destination="RC2-PX-VHu" id="eRu-fj-UUY"/>
+            </connections>
+        </placeholder>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="RC2-PX-VHu">
+            <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+            <subviews>
+                <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" translatesAutoresizingMaskIntoConstraints="NO" id="5Vn-Ge-dJG">
+                    <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                    <subviews>
+                        <view clearsContextBeforeDrawing="NO" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vSi-od-OQg" userLabel="Content View">
+                            <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                            <subviews>
+                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="qeh-ED-PxH">
+                                    <rect key="frame" x="20" y="99" width="180" height="67"/>
+                                    <color key="backgroundColor" systemColor="systemBrownColor" red="0.63529411759999999" green="0.51764705879999995" blue="0.36862745099999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                    <constraints>
+                                        <constraint firstAttribute="height" constant="67" id="gXb-X6-cEN"/>
+                                        <constraint firstAttribute="width" constant="180" id="obO-Lo-eqQ"/>
+                                    </constraints>
+                                    <viewLayoutGuide key="safeArea" id="99s-hC-NPV"/>
+                                </view>
+                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="pSZ-St-b39">
+                                    <rect key="frame" x="179" y="460" width="160" height="67"/>
+                                    <color key="backgroundColor" systemColor="systemBrownColor" red="0.63529411759999999" green="0.51764705879999995" blue="0.36862745099999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                    <constraints>
+                                        <constraint firstAttribute="height" constant="67" id="9hB-YZ-aa1"/>
+                                        <constraint firstAttribute="width" constant="160" id="gRX-ZD-gWp"/>
+                                    </constraints>
+                                    <viewLayoutGuide key="safeArea" id="Slw-ya-T96"/>
+                                </view>
+                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="bba-Ol-2un">
+                                    <rect key="frame" x="252" y="182" width="73" height="256"/>
+                                    <color key="backgroundColor" systemColor="systemBrownColor" red="0.63529411759999999" green="0.51764705879999995" blue="0.36862745099999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                    <constraints>
+                                        <constraint firstAttribute="width" constant="73" id="eeP-Ac-KOo"/>
+                                        <constraint firstAttribute="height" constant="256" id="zn9-0l-X0d"/>
+                                    </constraints>
+                                    <viewLayoutGuide key="safeArea" id="g0w-l6-RnH"/>
+                                </view>
+                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="0gv-mi-aQc">
+                                    <rect key="frame" x="50" y="366" width="73" height="256"/>
+                                    <color key="backgroundColor" systemColor="systemBrownColor" red="0.63529411759999999" green="0.51764705879999995" blue="0.36862745099999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                    <constraints>
+                                        <constraint firstAttribute="width" constant="73" id="PkN-np-7tv"/>
+                                        <constraint firstAttribute="height" constant="256" id="uei-nV-nbU"/>
+                                    </constraints>
+                                    <viewLayoutGuide key="safeArea" id="BEw-m8-qgo"/>
+                                </view>
+                            </subviews>
+                            <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                            <constraints>
+                                <constraint firstItem="0gv-mi-aQc" firstAttribute="top" secondItem="qeh-ED-PxH" secondAttribute="bottom" constant="200" id="IOE-Rw-Xcq"/>
+                                <constraint firstItem="pSZ-St-b39" firstAttribute="top" secondItem="bba-Ol-2un" secondAttribute="bottom" constant="22" id="MDd-aA-g6E"/>
+                                <constraint firstAttribute="trailing" secondItem="pSZ-St-b39" secondAttribute="trailing" constant="36" id="PEP-9q-AhP"/>
+                                <constraint firstAttribute="trailing" secondItem="bba-Ol-2un" secondAttribute="trailing" constant="50" id="Qga-Mz-Wzx"/>
+                                <constraint firstItem="qeh-ED-PxH" firstAttribute="top" secondItem="vSi-od-OQg" secondAttribute="top" constant="99" id="bf0-yy-I6R"/>
+                                <constraint firstItem="qeh-ED-PxH" firstAttribute="leading" secondItem="vSi-od-OQg" secondAttribute="leading" constant="20" id="hL8-9O-cZc"/>
+                                <constraint firstAttribute="bottom" secondItem="pSZ-St-b39" secondAttribute="bottom" constant="140" id="tye-a2-CxP"/>
+                                <constraint firstItem="bba-Ol-2un" firstAttribute="top" secondItem="qeh-ED-PxH" secondAttribute="bottom" constant="16" id="xgK-YZ-i0N"/>
+                                <constraint firstItem="0gv-mi-aQc" firstAttribute="leading" secondItem="vSi-od-OQg" secondAttribute="leading" constant="50" id="yNU-6N-Oof"/>
+                            </constraints>
+                        </view>
+                    </subviews>
+                    <constraints>
+                        <constraint firstItem="vSi-od-OQg" firstAttribute="leading" secondItem="5Vn-Ge-dJG" secondAttribute="leading" id="8p8-84-6Js"/>
+                        <constraint firstItem="vSi-od-OQg" firstAttribute="bottom" secondItem="5Vn-Ge-dJG" secondAttribute="bottom" constant="667" id="O4Q-My-slI"/>
+                        <constraint firstItem="vSi-od-OQg" firstAttribute="trailing" secondItem="5Vn-Ge-dJG" secondAttribute="trailing" constant="375" id="dFL-by-OyN"/>
+                        <constraint firstItem="vSi-od-OQg" firstAttribute="top" secondItem="5Vn-Ge-dJG" secondAttribute="top" id="uod-cx-iyK"/>
+                    </constraints>
+                </scrollView>
+            </subviews>
+            <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+            <constraints>
+                <constraint firstItem="vSi-od-OQg" firstAttribute="width" secondItem="RC2-PX-VHu" secondAttribute="width" id="3dO-3n-C8c"/>
+                <constraint firstItem="5Vn-Ge-dJG" firstAttribute="leading" secondItem="lQ3-G0-3fz" secondAttribute="leading" id="9yr-lz-EwM"/>
+                <constraint firstItem="5Vn-Ge-dJG" firstAttribute="top" secondItem="lQ3-G0-3fz" secondAttribute="top" id="cXV-VX-XlS"/>
+                <constraint firstItem="lQ3-G0-3fz" firstAttribute="bottom" secondItem="5Vn-Ge-dJG" secondAttribute="bottom" id="ehc-Ih-spg"/>
+                <constraint firstItem="lQ3-G0-3fz" firstAttribute="trailing" secondItem="5Vn-Ge-dJG" secondAttribute="trailing" id="zzb-73-qje"/>
+            </constraints>
+            <viewLayoutGuide key="safeArea" id="lQ3-G0-3fz"/>
+            <point key="canvasLocation" x="165.59999999999999" y="154.27286356821591"/>
+        </view>
+    </objects>
+</document>

--- a/Example/AndesUI/Coachmark/Views/CoachmarkViewController.swift
+++ b/Example/AndesUI/Coachmark/Views/CoachmarkViewController.swift
@@ -34,7 +34,10 @@ class CoachmarkViewController: UIViewController {
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        coachmark?.start()
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
+            self.coachmark?.start()
+        }
     }
 
     private func setupViews() {

--- a/LibraryComponents/Classes/AndesCoachmark/Entities/AndesCoachMarkEntity.swift
+++ b/LibraryComponents/Classes/AndesCoachmark/Entities/AndesCoachMarkEntity.swift
@@ -5,12 +5,12 @@
 //  Created by JONATHAN DANIEL BANDONI on 24/04/2020.
 //
 
-public struct AndesCoachMarkEntity {
+@objc public class AndesCoachMarkEntity: NSObject {
     let steps: [AndesCoachMarkStepEntity]
     let scrollView: UIScrollView?
     let completionHandler: (() -> Void)?
 
-    public init(steps: [AndesCoachMarkStepEntity],
+    @objc public init(steps: [AndesCoachMarkStepEntity],
                 scrollView: UIScrollView?,
                 completionHandler: (() -> Void)?) {
 

--- a/LibraryComponents/Classes/AndesCoachmark/Entities/AndesCoachMarkStepEntity.swift
+++ b/LibraryComponents/Classes/AndesCoachmark/Entities/AndesCoachMarkStepEntity.swift
@@ -5,26 +5,26 @@
 //  Created by JONATHAN DANIEL BANDONI on 04/06/2020.
 //
 
-public struct AndesCoachMarkStepEntity {
-    public enum Style {
+@objc public class AndesCoachMarkStepEntity: NSObject {
+    @objc public enum HighlightStyle: Int {
         case rectangle
         case circle
     }
 
     let title: String
-    let description: String
+    let descriptionText: String
     let view: UIView
-    let style: Style
+    let style: HighlightStyle
     let nextText: String
 
-    public init (title: String,
+    @objc public init (title: String,
                  description: String,
                  view: UIView,
-                 style: Style,
+                 style: HighlightStyle,
                  nextText: String) {
 
         self.title = title
-        self.description = description
+        self.descriptionText = description
         self.nextText = nextText
         self.view = view
         self.style = style

--- a/LibraryComponents/Classes/AndesCoachmark/Interactors/AndesCoachMarkHighlightInteractor.swift
+++ b/LibraryComponents/Classes/AndesCoachmark/Interactors/AndesCoachMarkHighlightInteractor.swift
@@ -12,20 +12,20 @@ protocol AndesCoachMarkHighlightInteractorProtocol: class {
     func getHighlightCornerRadius() -> CGFloat
     func getMaskPath() -> CGPath
     func isHighlightedViewBelow() -> Bool
-    func update(view: UIView, style: AndesCoachMarkStepEntity.Style)
+    func update(view: UIView, style: AndesCoachMarkStepEntity.HighlightStyle)
 }
 
 class AndesCoachMarkHighlightInteractor {
 
     private var view: UIView
-    private var style: AndesCoachMarkStepEntity.Style
+    private var style: AndesCoachMarkStepEntity.HighlightStyle
     private let overlayView: UIView
     private let bodyViewBounds: CGRect
     private let margin: CGFloat
 
     private var highlightedRect: CGRect { highlightedRectCalculation() }
 
-    required init (overlayView: UIView, view: UIView, bodyViewBounds: CGRect, style: AndesCoachMarkStepEntity.Style, margin: CGFloat = AndesCoachMarkConstants.Highlight.margin) {
+    required init (overlayView: UIView, view: UIView, bodyViewBounds: CGRect, style: AndesCoachMarkStepEntity.HighlightStyle, margin: CGFloat = AndesCoachMarkConstants.Highlight.margin) {
         self.overlayView = overlayView
         self.view = view
         self.bodyViewBounds = bodyViewBounds
@@ -60,10 +60,10 @@ class AndesCoachMarkHighlightInteractor {
         if rect.minY < container.minY || rect.maxY > container.maxY {
             return false
         }
-        
+
         return true
     }
-    
+
     private func buildSquareFrom(rect: CGRect, margin: CGFloat) -> UIBezierPath {
         return UIBezierPath(roundedRect: rect.insetBy(dx: -margin, dy: -margin), cornerRadius: AndesCoachMarkConstants.Highlight.cornerRadius)
     }
@@ -75,7 +75,7 @@ class AndesCoachMarkHighlightInteractor {
 }
 
 extension AndesCoachMarkHighlightInteractor: AndesCoachMarkHighlightInteractorProtocol {
-    func update(view: UIView, style: AndesCoachMarkStepEntity.Style) {
+    func update(view: UIView, style: AndesCoachMarkStepEntity.HighlightStyle) {
         self.view = view
         self.style = style
     }

--- a/LibraryComponents/Classes/AndesCoachmark/Presenter/CECoachMarkPresenter.swift
+++ b/LibraryComponents/Classes/AndesCoachmark/Presenter/CECoachMarkPresenter.swift
@@ -64,7 +64,7 @@ class AndesCoachMarkPresenter {
     private func setBody(_ position: AndesCoachMarkBodyEntity.Position, removePrevious: Bool) {
         guard let view = view, let currentStep = currentStep else { return }
         view.setBody(AndesCoachMarkBodyPresenter(model: AndesCoachMarkBodyEntity(title: currentStep.title,
-                                                                           description: currentStep.description,
+                                                                           description: currentStep.descriptionText,
                                                                            viewToPoint: currentStep.view,
                                                                            position: position)), removePrevious: removePrevious)
     }

--- a/LibraryComponents/Classes/AndesCoachmark/View/AndesCoachMarkView.swift
+++ b/LibraryComponents/Classes/AndesCoachmark/View/AndesCoachMarkView.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-public class AndesCoachMarkView: UIView {
+@objc public class AndesCoachMarkView: UIView {
     let overlayLayer = CAShapeLayer()
     let maskLayer = CAShapeLayer()
 

--- a/LibraryComponents/Classes/AndesCoachmark/View/AndesCoachMarkView.swift
+++ b/LibraryComponents/Classes/AndesCoachmark/View/AndesCoachMarkView.swift
@@ -11,8 +11,8 @@ import UIKit
     let overlayLayer = CAShapeLayer()
     let maskLayer = CAShapeLayer()
 
-    public weak var delegate: AndesCoachMarkViewDelegate?
-    public let overlayColor: UIColor = UIColor.Andes.gray800
+    @objc public weak var delegate: AndesCoachMarkViewDelegate?
+    @objc public let overlayColor: UIColor = UIColor.Andes.gray800
 
     var highlightedView: AndesCoachMarkHighlightedView?
 

--- a/LibraryComponents/Classes/AndesCoachmark/View/AndesCoachMarkView.swift
+++ b/LibraryComponents/Classes/AndesCoachmark/View/AndesCoachMarkView.swift
@@ -40,7 +40,7 @@ public class AndesCoachMarkView: UIView {
     var onExit: (() -> Void)?
 
     // MARK: - Initialization
-    public init(model: AndesCoachMarkEntity) {
+    @objc public init(model: AndesCoachMarkEntity) {
         self.onExit = model.completionHandler
         self.presenter = AndesCoachMarkPresenter(model: model)
 
@@ -100,7 +100,7 @@ public class AndesCoachMarkView: UIView {
         fatalError("This class does not support NSCoding")
     }
 
-    public func start() {
+    @objc public func start() {
         presenter.start()
     }
 

--- a/LibraryComponents/Classes/AndesCoachmark/View/AndesCoachMarkViewDelegate.swift
+++ b/LibraryComponents/Classes/AndesCoachmark/View/AndesCoachMarkViewDelegate.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public protocol AndesCoachMarkViewDelegate: class {
-    func onShowNext(stepIndex: Int)
-    func onClose(stepIndex: Int)
+@objc public protocol AndesCoachMarkViewDelegate: class {
+    @objc func onShowNext(stepIndex: Int)
+    @objc func onClose(stepIndex: Int)
 }


### PR DESCRIPTION
Se hacen los cambios para soportar ObjC!

<img src="https://user-images.githubusercontent.com/42151272/91900723-7a92ef00-ec75-11ea-8cc4-95661a381beb.png" width=300>


## Checks
Are you sure you followed all those steps? If so, repeat after me "I solemnly swear that ...":
   - [x] I have coded an example inside the Demo App,
   - [x] I have added proper tests,
   - [x] I have modified the Changelog.md file,
   - [x] I have updated GitHub wiki,
   - [x] I have the explicit approval of one or more members of the UX Team,
   - [x] I have checked that this code is ObjC compliant.
   - [x] I have checked that all the new public enums conform to AndesEnumStringConvertible.
## Change type
This is easy, let us know what this code is about:
   - [ ] This code adds a new component
   - [x] This code includes improvements to an existent component
   - [ ] This code improves or modifies ONLY the Demo App.
