### PR TITLE
AndesMessage body lineHeight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## (to be published)
+### 🛠 Bug fixes
+- AndesMessage body `lineHeight` changed  | Authors: [@lelalesi](https://github.com/lelalesi)
+
 ## v3.9.0
 ### 🚀 Features
 - New component: AndesCoachMark | Authors: [@jdbandoniml](https://github.com/jdbandoniml)

--- a/LibraryComponents/Classes/Core/AndesMessage/Config/AndesMessageViewConfig.swift
+++ b/LibraryComponents/Classes/Core/AndesMessage/Config/AndesMessageViewConfig.swift
@@ -62,6 +62,6 @@ internal struct AndesMessageViewConfig {
     }
 
     private static func getBodyStyle(_ color: UIColor) -> AndesFontStyle {
-        return AndesFontStyle(textColor: color, font: AndesStyleSheetManager.styleSheet.regularSystemFont(size: 14), sketchLineHeight: 20)
+        return AndesFontStyle(textColor: color, font: AndesStyleSheetManager.styleSheet.regularSystemFont(size: 14), sketchLineHeight: 18)
     }
 }


### PR DESCRIPTION
### Thanks for contributing to Andes UI!
## Description
- AndesMessage body `lineHeight` value changed from 20pt to 18pt. 
The interSpacing between text lines wasn't matching the one specified in Andes zeplin.

| Before | After |
| --- | --- |
|<img width="312" alt="Before" src="https://user-images.githubusercontent.com/58035996/93806093-07025300-fc1f-11ea-9c61-5bfac1b0f807.png">|<img width="312" alt="after" src="https://user-images.githubusercontent.com/58035996/93806104-0d90ca80-fc1f-11ea-9277-ebd87c130168.png">|

## Affected component
- AndesMessage
## RFC Link
- N/A
## Checks
Are you sure you followed all those steps? If so, repeat after me "I solemnly swear that ...":
   - [ ] I have coded an example inside the Demo App,
   - [ ] I have added proper tests,
   - [x] I have modified the Changelog.md file,
   - [ ] I have updated GitHub wiki,
   - [x] I have the explicit approval of one or more members of the UX Team,
   - [x] I have checked that this code is ObjC compliant.
   - [x] I have checked that all the new public enums conform to AndesEnumStringConvertible.
## Change type
This is easy, let us know what this code is about:
   - [ ] This code adds a new component
   - [x] This code includes improvements to an existent component
   - [ ] This code improves or modifies ONLY the Demo App.
