### PR TITLE
Adding AndesTagChoice accessibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## (to be published)
+### 🚀 Features
+- Adding accessibility to AndesTagChoice component | Authors: [@fconilmeli](https://github.com/fconilmeli)
 
 ## v3.10.0
 ### 🚀 Features

--- a/LibraryComponents/Classes/Core/AndesTag/Config/AndesTagViewConfig.swift
+++ b/LibraryComponents/Classes/Core/AndesTag/Config/AndesTagViewConfig.swift
@@ -34,9 +34,11 @@ internal struct AndesTagViewConfig {
 
     var shouldAnimateRightContent: Bool = false
 
+    var accessibilityLabel: String = ""
+
     init() {}
 
-    init(backgroundColor: UIColor, borderColor: UIColor, buttonColor: UIColor, height: CGFloat, horizontalPadding: CGFloat, cornerRadius: CGFloat, text: String?, textFont: UIFont, textColor: UIColor, leftContent: AndesTagLeftContent? = nil, rightButtonImageName: String?, rightButtonWidth: CGFloat, shouldAnimateRightContent: Bool = false) {
+    init(backgroundColor: UIColor, borderColor: UIColor, buttonColor: UIColor, height: CGFloat, horizontalPadding: CGFloat, cornerRadius: CGFloat, text: String?, textFont: UIFont, textColor: UIColor, leftContent: AndesTagLeftContent? = nil, rightButtonImageName: String?, rightButtonWidth: CGFloat, shouldAnimateRightContent: Bool = false, accessibilityLabel: String) {
         self.backgroundColor = backgroundColor
         self.borderColor = borderColor
         self.buttonColor = buttonColor
@@ -50,5 +52,6 @@ internal struct AndesTagViewConfig {
         self.rightButtonImageName = rightButtonImageName
         self.rightButtonWidth = rightButtonWidth
         self.shouldAnimateRightContent = shouldAnimateRightContent
+        self.accessibilityLabel = accessibilityLabel
     }
 }

--- a/LibraryComponents/Classes/Core/AndesTag/Config/AndesTagViewConfigFactory.swift
+++ b/LibraryComponents/Classes/Core/AndesTag/Config/AndesTagViewConfigFactory.swift
@@ -30,7 +30,9 @@ internal class AndesTagViewConfigFactory {
         let rightButtonWidth = tag.isDismissible ? size.rightButtonWidth : 0
         let rightButtonImageName = tag.isDismissible ? AndesIcons.close16 : nil
 
-        return AndesTagViewConfig(backgroundColor: backgroundColor, borderColor: borderColor, buttonColor: buttonColor, height: height, horizontalPadding: horizontalPadding, cornerRadius: cornerRadius, text: text, textFont: textFont, textColor: textColor, leftContent: leftContent, rightButtonImageName: rightButtonImageName, rightButtonWidth: rightButtonWidth)
+        let accesibilityLabel = "Cerrar".localized()
+
+        return AndesTagViewConfig(backgroundColor: backgroundColor, borderColor: borderColor, buttonColor: buttonColor, height: height, horizontalPadding: horizontalPadding, cornerRadius: cornerRadius, text: text, textFont: textFont, textColor: textColor, leftContent: leftContent, rightButtonImageName: rightButtonImageName, rightButtonWidth: rightButtonWidth, accessibilityLabel: accesibilityLabel)
     }
 
     static func provideInternalConfig(fromChoiceTag tag: AndesTagChoice) -> AndesTagViewConfig {
@@ -64,6 +66,9 @@ internal class AndesTagViewConfigFactory {
 
         let shouldAnimateRightContent: Bool = tag.shouldAnimateTag
 
-        return AndesTagViewConfig(backgroundColor: backgroundColor, borderColor: borderColor, buttonColor: buttonColor, height: height, horizontalPadding: horizontalPadding, cornerRadius: cornerRadius, text: text, textFont: textFont, textColor: textColor, leftContent: leftContent, rightButtonImageName: rightButtonImageName, rightButtonWidth: rightButtonWidth, shouldAnimateRightContent: shouldAnimateRightContent)
+        let accessibilityTextSelected = tag.state == .selected ? "Seleccionado".localized() : ""
+        let accessibilityLabel = "\(text ?? "")\(accessibilityTextSelected)"
+
+        return AndesTagViewConfig(backgroundColor: backgroundColor, borderColor: borderColor, buttonColor: buttonColor, height: height, horizontalPadding: horizontalPadding, cornerRadius: cornerRadius, text: text, textFont: textFont, textColor: textColor, leftContent: leftContent, rightButtonImageName: rightButtonImageName, rightButtonWidth: rightButtonWidth, shouldAnimateRightContent: shouldAnimateRightContent, accessibilityLabel: accessibilityLabel)
     }
 }

--- a/LibraryComponents/Classes/Core/AndesTag/View/AndesTagChoiceView.swift
+++ b/LibraryComponents/Classes/Core/AndesTag/View/AndesTagChoiceView.swift
@@ -12,11 +12,12 @@ class AndesTagChoiceView: AndesTagSimpleView {
     override func updateView() {
         super.updateView()
         self.rightButton.isUserInteractionEnabled = false
+        self.isAccessibilityElement = true
+        self.accessibilityLabel = config.accessibilityLabel
     }
 
     override func setupRightContent() {
         super.setupRightContent()
-        self.rightButton.isAccessibilityElement = false
         if config.shouldAnimateRightContent {
             UIView.animate(withDuration: 0.3) {
                 self.layoutIfNeeded()

--- a/LibraryComponents/Classes/Core/AndesTag/View/AndesTagSimpleView.swift
+++ b/LibraryComponents/Classes/Core/AndesTag/View/AndesTagSimpleView.swift
@@ -40,7 +40,7 @@ class AndesTagSimpleView: AndesTagAbstractView {
             }
             self.rightButton.tintColor = self.config.buttonColor
             self.trailingConstraint.constant = 0
-            self.rightButton.accessibilityLabel = "Cerrar".localized()
+            self.rightButton.accessibilityLabel = config.accessibilityLabel
         } else {
             self.trailingConstraint.constant = config.horizontalPadding ?? 0
         }


### PR DESCRIPTION
### Thanks for contributing to Andes UI!
## Description

Adding accessibility label to AndesTagChoice view. The text is the tag title + selected state
## Checks
Are you sure you followed all those steps? If so, repeat after me "I solemnly swear that ...":
   - [ ] I have coded an example inside the Demo App,
   - [ ] I have added proper tests,
   - [x] I have modified the Changelog.md file,
   - [ ] I have updated GitHub wiki,
   - [ ] I have the explicit approval of one or more members of the UX Team,
   - [ ] I have checked that this code is ObjC compliant.
   - [ ] I have checked that all the new public enums conform to AndesEnumStringConvertible.
## Change type
This is easy, let us know what this code is about:
   - [ ] This code adds a new component
   - [x] This code includes improvements to an existent component
   - [ ] This code improves or modifies ONLY the Demo App.
