### PR TITLE
SwiftLint allow underscore [TRIVIAL]

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -12,3 +12,5 @@ file_length:
   warning: 500
   error: 1200
 reporter: "xcode" # reporter type (xcode, json, csv, checkstyle, junit, html, emoji, sonarqube, markdown)
+identifier_name:
+  allowed_symbols: "_"


### PR DESCRIPTION
## Description
In order to keep both iOS and Android libraries similar, we are allowing variable names to contain underscores *_*. While coding AndesTextCode component, the enums were defined using underscores (*THREE_BY_THREE*) in the RFC. Android's component was built using this definition before realising this lint rule was enabled. So, we are allowing this naming convention just for cross-platform similarity.

## Affected component
None, it's backwards compatible
