### PR TITLE
[FIXES] Fixes in App Delegate and Page Controller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unpublished
 ### 🚀 Features
 - Xcode 12 compatibility
+- Fixes in App Delegate and Page Controller in Test App
 
 # v3.12.0
 ### 🚀 Features

--- a/Example/AndesUI/AndesUIAppDelegate.swift
+++ b/Example/AndesUI/AndesUIAppDelegate.swift
@@ -25,12 +25,7 @@ class AndesUIAppDelegate: UIResponder, UIApplicationDelegate {
         UINavigationBar.appearance().titleTextAttributes = [NSAttributedString.Key.foregroundColor: AndesStyleSheetManager.styleSheet.bgColorWhite]
 
         self.window = UIWindow(frame: UIScreen.main.bounds)
-        let viewController = UIViewController()
-        let navController = UINavigationController(rootViewController: viewController)
-        window?.rootViewController = navController
-        window?.makeKeyAndVisible()
-
-        homeRouter.route(from: viewController)
+        homeRouter.start(in: window!)
 
         // Disable dark mode.
         if #available(iOS 13.0, *) {

--- a/Example/AndesUI/Home/Routers/HomeRouter.swift
+++ b/Example/AndesUI/Home/Routers/HomeRouter.swift
@@ -9,7 +9,7 @@
 import UIKit
 
 protocol HomeRouter: NSObject {
-    func route(from: UIViewController)
+    func start(in window: UIWindow)
     func routeToCoachmark()
     func routeToButton()
     func routeToMessages()
@@ -46,14 +46,12 @@ class HomeAppRouter: NSObject {
 
 extension HomeAppRouter: HomeRouter {
 
-    func route(from: UIViewController) {
+    func start(in window: UIWindow) {
         presenter = HomeViewPresenter(view: view, router: self)
         view.presenter = presenter
 
-        let navigation = UINavigationController(rootViewController: view)
-        navigation.modalPresentationStyle = .fullScreen
-
-        from.present(navigation, animated: false, completion: nil)
+        window.rootViewController = UINavigationController(rootViewController: view)
+        window.makeKeyAndVisible()
     }
 
     func routeToCoachmark() {

--- a/Example/AndesUI/PageController/AndesShowcasePageViewController.swift
+++ b/Example/AndesUI/PageController/AndesShowcasePageViewController.swift
@@ -8,6 +8,7 @@
 
 import UIKit
 import AndesUI
+
 class AndesShowcasePageViewController: UIViewController {
     @IBOutlet var pageControl: UIPageControl!
     @IBOutlet weak var containerView: UIView!
@@ -26,19 +27,24 @@ class AndesShowcasePageViewController: UIViewController {
         fatalError("init(coder:) has not been implemented")
     }
 
-    fileprivate func setupPageControl() {
+    private func setupPageControl() {
         pageControl.pageIndicatorTintColor = UIColor.gray
         pageControl.currentPageIndicatorTintColor = AndesStyleSheetManager.styleSheet.brandColor500
         pageControl.numberOfPages = controllers.count
     }
 
-    fileprivate func setupPageController() {
+    private func setupPageController() {
         pageController = UIPageViewController(transitionStyle: .scroll, navigationOrientation: .horizontal, options: nil)
         pageController.dataSource = self
         pageController.delegate = self
-        pageController.setViewControllers([controllers.first!], direction: .forward, animated: true, completion: nil)
+
+        pageController.willMove(toParentViewController: self)
+        addChildViewController(pageController)
         containerView.addSubview(pageController.view)
         pageController.view.pinTo(view: self.containerView)
+        pageController.didMove(toParentViewController: self)
+
+        pageController.setViewControllers([controllers.first!], direction: .forward, animated: true, completion: nil)
     }
 
     override func viewDidLoad() {

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,11 +1,11 @@
 PODS:
-  - AndesUI (3.9.1):
-    - AndesUI/Core (= 3.9.1)
-  - AndesUI/AndesCoachmark (3.9.1):
+  - AndesUI (3.12.0):
+    - AndesUI/Core (= 3.12.0)
+  - AndesUI/AndesCoachmark (3.12.0):
     - AndesUI/Core
-  - AndesUI/Core (3.9.1):
+  - AndesUI/Core (3.12.0):
     - AndesUI/LocalIcons
-  - AndesUI/LocalIcons (3.9.1)
+  - AndesUI/LocalIcons (3.12.0)
   - IQKeyboardManagerSwift (6.3.0)
   - Nimble (7.3.4)
   - Quick (1.2.0)
@@ -28,7 +28,7 @@ EXTERNAL SOURCES:
     :path: "./"
 
 SPEC CHECKSUMS:
-  AndesUI: 8439bef97a5707000ad1b62b6800d5f4967c74bf
+  AndesUI: d423b05940f82a8d52d114c2287b460b30ed38aa
   IQKeyboardManagerSwift: a8228c257614af98743b4cd8584637025f36358f
   Nimble: 051e3d8912d40138fa5591c78594f95fb172af37
   Quick: 58d203b1c5e27fff7229c4c1ae445ad7069a7a08


### PR DESCRIPTION
### Thanks for contributing to Andes UI!
## Description

There were some issues with the Test App:

1. The Test App init flow resulted in the creation of unused view controllers. It also meant that the whole app ran in a presented view controller instead of as the root view controller of the main window.

2. The PageController (used extensively in the examples) was missing a key piece of the *add child* boilerplate resulting in an inconsistent behavior in the contained view controllers.

This fixes removed the warnings that were shown at launch in the debugging console:

```
2020-10-30 02:28:14.095221-0300 AndesUI DemoApp[47531:24178789] Presenting view controllers on detached view controllers is discouraged <UIViewController: 0x7fabcf5568e0>.
2020-10-30 02:28:14.329492-0300 AndesUI DemoApp[47531:24178789] Unbalanced calls to begin/end appearance transitions for <UINavigationController: 0x7fabd001da00>.
```

## Checks
Are you sure you followed all those steps? If so, repeat after me "I solemnly swear that ...":
   - [ ] I have coded an example inside the Demo App,
   - [ ] I have added proper tests,
   - [x] I have modified the Changelog.md file,
   - [ ] I have updated GitHub wiki,
   - [ ] I have the explicit approval of one or more members of the UX Team,
   - [x] I have checked that this code is ObjC compliant.
   - [ ] I have checked that all the new public enums conform to AndesEnumStringConvertible.

## Change type
This is easy, let us know what this code is about:
   - [ ] This code adds a new component
   - [ ] This code includes improvements to an existent component
   - [x] This code improves or modifies ONLY the Demo App.
