### PR TITLE
Add inputAccessoryView to AndesTextField

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unpublished
 ### 🚀 Features
-- Xcode 12 compatibility
+- Xcode 12 compatibility | Authors: [@Mobile-Arq](https://github.com/mercadolibre/fury_andesui-ios)
+- AndesTextField adds support of inputAccessoryView | Authors: [@Mobile-Arq](https://github.com/mercadolibre/fury_andesui-ios)
 
 # v3.12.0
 ### 🚀 Features

--- a/LibraryComponents/Classes/Core/AndesTextField/AndesTextArea.swift
+++ b/LibraryComponents/Classes/Core/AndesTextField/AndesTextArea.swift
@@ -165,6 +165,15 @@ extension AndesTextArea {
             contentView.customInputView = newValue
         }
     }
+
+    @objc override public var inputAccessoryView: UIView? {
+        get {
+            return contentView.customInputAccessoryView
+        }
+        set {
+            contentView.customInputAccessoryView = newValue
+        }
+    }
 }
 
 extension AndesTextArea: AndesTextFieldViewDelegate {

--- a/LibraryComponents/Classes/Core/AndesTextField/AndesTextField.swift
+++ b/LibraryComponents/Classes/Core/AndesTextField/AndesTextField.swift
@@ -172,6 +172,15 @@ extension AndesTextField {
             contentView.customInputView = newValue
         }
     }
+
+    @objc override public var inputAccessoryView: UIView? {
+        get {
+            return contentView.customInputAccessoryView
+        }
+        set {
+            contentView.customInputAccessoryView = newValue
+        }
+    }
 }
 
 extension AndesTextField: AndesTextFieldViewDelegate {

--- a/LibraryComponents/Classes/Core/AndesTextField/View/AndesTextFieldAbstractView.swift
+++ b/LibraryComponents/Classes/Core/AndesTextField/View/AndesTextFieldAbstractView.swift
@@ -20,6 +20,7 @@ class AndesTextFieldAbstractView: UIView, AndesTextFieldView {
     var borderLayer: CAShapeLayer?
     var text: String = ""
     var customInputView: UIView?
+    var customInputAccessoryView: UIView?
     weak var delegate: AndesTextFieldViewDelegate?
 
     var config: AndesTextFieldViewConfig

--- a/LibraryComponents/Classes/Core/AndesTextField/View/AndesTextFieldView.swift
+++ b/LibraryComponents/Classes/Core/AndesTextField/View/AndesTextFieldView.swift
@@ -14,6 +14,7 @@ internal protocol AndesTextFieldView: UIView {
     var text: String { get set } // input text
     var config: AndesTextFieldViewConfig { get }
     var customInputView: UIView? {get set}
+    var customInputAccessoryView: UIView? { get set }
     func update(withConfig config: AndesTextFieldViewConfig)
     func clear()
 }

--- a/LibraryComponents/Classes/Core/AndesTextField/View/Default/AndesTextFieldDefaultView.swift
+++ b/LibraryComponents/Classes/Core/AndesTextField/View/Default/AndesTextFieldDefaultView.swift
@@ -32,6 +32,17 @@ class AndesTextFieldDefaultView: AndesTextFieldAbstractView {
         }
     }
 
+    private var accessoryView: UIView?
+    override var customInputAccessoryView: UIView? {
+        get {
+            return accessoryView
+        }
+        set (value) {
+            accessoryView = value
+            textField.inputAccessoryView = value
+        }
+    }
+
     var currentVisibilities: [AndesTextFieldComponentVisibility] {
         return self.text.isEmpty ? [.always] : [.always, .whenNotEmpty]
     }

--- a/LibraryComponents/Classes/Core/AndesTextField/View/TextArea/AndesTextAreaView.swift
+++ b/LibraryComponents/Classes/Core/AndesTextField/View/TextArea/AndesTextAreaView.swift
@@ -30,6 +30,17 @@ class AndesTextAreaView: AndesTextFieldAbstractView {
         }
     }
 
+    private var accessoryView: UIView?
+    override var customInputAccessoryView: UIView? {
+        get {
+            return accessoryView
+        }
+        set (value) {
+            accessoryView = value
+            textView.inputAccessoryView = value
+        }
+    }
+
     override func loadNib() {
         let bundle = AndesBundle.bundle()
         bundle.loadNibNamed("AndesTextAreaView", owner: self, options: nil)

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,11 +1,11 @@
 PODS:
-  - AndesUI (3.9.1):
-    - AndesUI/Core (= 3.9.1)
-  - AndesUI/AndesCoachmark (3.9.1):
+  - AndesUI (3.12.0):
+    - AndesUI/Core (= 3.12.0)
+  - AndesUI/AndesCoachmark (3.12.0):
     - AndesUI/Core
-  - AndesUI/Core (3.9.1):
+  - AndesUI/Core (3.12.0):
     - AndesUI/LocalIcons
-  - AndesUI/LocalIcons (3.9.1)
+  - AndesUI/LocalIcons (3.12.0)
   - IQKeyboardManagerSwift (6.3.0)
   - Nimble (7.3.4)
   - Quick (1.2.0)
@@ -28,7 +28,7 @@ EXTERNAL SOURCES:
     :path: "./"
 
 SPEC CHECKSUMS:
-  AndesUI: 8439bef97a5707000ad1b62b6800d5f4967c74bf
+  AndesUI: d423b05940f82a8d52d114c2287b460b30ed38aa
   IQKeyboardManagerSwift: a8228c257614af98743b4cd8584637025f36358f
   Nimble: 051e3d8912d40138fa5591c78594f95fb172af37
   Quick: 58d203b1c5e27fff7229c4c1ae445ad7069a7a08


### PR DESCRIPTION
### Thanks for contributing to Andes UI!
## Description
The `inputAccessoryView` property is added to all the AndesTextFields options. This property allows the developer to configure a custom view on top of the keyboard, such as `UIToolbar` with a _done_ button.

#### Why do we need it?
It's a standard behaviour of every `UITextField` mainly for adding dismissal buttons for the keyboard. There is no way to close the keyboard natively. The developer needs to add a touch handler to detect taps outside the keyboard, or add a toolbar with a button. We are unable to add the toolbar without this property being public.

This property is available by default on `UITextField`. Since `AndesTextField` is a custom textfield with `UIView` inheritance,  the property is not available for usage.

#### How does it work?
It just retransmits the property down to the the native `UITextField` inside `AndesTextField`

## Affected component
- AndesTextField
- AndesTextArea
- AndesTextFieldCode

## Screenshots / GIFs
This is just an example. This property gives the developer the ability to add this toolbar, it's not enabled by default.

| Before                                                                                                                           | After                                                                                                                             |
|----------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------|
| ![ezgif com-gif-maker (9)](https://user-images.githubusercontent.com/12042857/98035540-6e531b80-1df7-11eb-851b-5c050666c8bb.gif) | ![ezgif com-gif-maker (10)](https://user-images.githubusercontent.com/12042857/98035533-6bf0c180-1df7-11eb-80d6-4a13242ea364.gif) |

## Checks
Are you sure you followed all those steps? If so, repeat after me "I solemnly swear that ...":
   - [ ] I have coded an example inside the Demo App,
   - [ ] I have added proper tests,
   - [x] I have modified the Changelog.md file,
   - [ ] I have updated GitHub wiki,
   - [ ] I have the explicit approval of one or more members of the UX Team,
   - [x] I have checked that this code is ObjC compliant.
   - [ ] I have checked that all the new public enums conform to AndesEnumStringConvertible.

## Change type
This is easy, let us know what this code is about:
   - [ ] This code adds a new component
   - [x] This code includes improvements to an existent component
   - [ ] This code improves or modifies ONLY the Demo App.
