### PR TITLE
Fix - AndesCheckbox Tappable Area

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 ### 🚀 Features
 - Xcode 12 compatibility
 
+### 🛠 Bug fixes
+- AndesCheckbox tappable area extended  | Authors: [@ggiovanniniml](https://github.com/ggiovanniniml)
+
 # v3.12.0
 ### 🚀 Features
 - New component AndesTextFieldCode | Authors: [@eboffa](https://github.com/eboffa)

--- a/LibraryComponents/Classes/Core/AndesCheckbox/View/AndesCheckboxDefaultView.swift
+++ b/LibraryComponents/Classes/Core/AndesCheckbox/View/AndesCheckboxDefaultView.swift
@@ -17,10 +17,9 @@ class AndesCheckboxDefaultView: UIView, AndesCheckboxView {
     @IBOutlet weak var labelToTrailingConstraint: NSLayoutConstraint!
 
     @IBOutlet weak var leftBox: UIImageView!
-    @IBOutlet weak var leftTappableArea: UIButton!
-
     @IBOutlet weak var rightBox: UIImageView!
-    @IBOutlet weak var rightTappableArea: UIButton!
+    
+    @IBOutlet weak var tappableArea: UIButton!
 
     @IBOutlet var checkboxView: UIView!
 
@@ -40,11 +39,7 @@ class AndesCheckboxDefaultView: UIView, AndesCheckboxView {
         updateView()
     }
 
-    @IBAction func leftButtonTapped(_ sender: Any) {
-        self.delegate?.checkboxTapped()
-    }
-
-    @IBAction func rightButtonTapped(_ sender: Any) {
+    @IBAction func checkboxTapped(_ sender: Any) {
         self.delegate?.checkboxTapped()
     }
 
@@ -116,8 +111,6 @@ class AndesCheckboxDefaultView: UIView, AndesCheckboxView {
         if config.align == .left {
             self.rightBox.isHidden = true
             self.leftBox.isHidden = false
-            self.rightTappableArea.isHidden = true
-            self.leftTappableArea.isHidden = false
             self.leftBox.backgroundColor = config.backgroundColor
             self.leftBox.layer.cornerRadius = config.cornerRadius
             self.labelToTrailingConstraint.priority = .defaultHigh
@@ -127,8 +120,6 @@ class AndesCheckboxDefaultView: UIView, AndesCheckboxView {
         } else {
             self.rightBox.isHidden = false
             self.leftBox.isHidden = true
-            self.rightTappableArea.isHidden = false
-            self.leftTappableArea.isHidden = true
             self.rightBox.backgroundColor = config.backgroundColor
             self.rightBox.layer.cornerRadius = config.cornerRadius
             self.labelToTrailingConstraint.priority = .defaultLow
@@ -152,13 +143,8 @@ class AndesCheckboxDefaultView: UIView, AndesCheckboxView {
 
     func updateAccessibilityProperties() {
         if let accessibilityTraits = self.delegate?.buttonAccesibilityTraits() {
-            if config.align == .left {
-                self.leftTappableArea.accessibilityTraits = accessibilityTraits
-                self.leftTappableArea.accessibilityLabel = config.title
-            } else {
-                self.rightTappableArea.accessibilityTraits = accessibilityTraits
-                self.rightTappableArea.accessibilityLabel = config.title
-            }
+            self.tappableArea.accessibilityTraits = accessibilityTraits
+            self.tappableArea.accessibilityLabel = config.title
         }
     }
 

--- a/LibraryComponents/Classes/Core/AndesCheckbox/View/Default/AndesCheckboxDefaultView.xib
+++ b/LibraryComponents/Classes/Core/AndesCheckbox/View/Default/AndesCheckboxDefaultView.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16097" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17125"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -16,9 +16,8 @@
                 <outlet property="labelToRightButtonConstraint" destination="Qge-6P-F47" id="bzG-3O-8jp"/>
                 <outlet property="labelToTrailingConstraint" destination="hp5-bY-WMe" id="p5x-qk-CmA"/>
                 <outlet property="leftBox" destination="dhw-ue-pA7" id="47f-pd-6oD"/>
-                <outlet property="leftTappableArea" destination="tab-mw-4wG" id="QT5-mI-tkd"/>
                 <outlet property="rightBox" destination="cJx-ya-F6a" id="Xxf-8m-7SZ"/>
-                <outlet property="rightTappableArea" destination="lmV-Ba-ZbW" id="Ct7-QR-b78"/>
+                <outlet property="tappableArea" destination="tab-mw-4wG" id="QT5-mI-tkd"/>
             </connections>
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
@@ -48,40 +47,26 @@
                         <constraint firstAttribute="width" constant="16" id="y19-ze-T7D"/>
                     </constraints>
                 </imageView>
-                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="tab-mw-4wG">
-                    <rect key="frame" x="4" y="8" width="32" height="32"/>
-                    <constraints>
-                        <constraint firstAttribute="height" constant="32" id="HLY-FP-5tZ"/>
-                        <constraint firstAttribute="width" constant="32" id="wJs-Go-3sK"/>
-                    </constraints>
+                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="tab-mw-4wG">
+                    <rect key="frame" x="0.0" y="0.0" width="153" height="48"/>
                     <connections>
-                        <action selector="leftButtonTapped:" destination="-1" eventType="touchUpInside" id="5xn-MI-IFl"/>
-                    </connections>
-                </button>
-                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="lmV-Ba-ZbW">
-                    <rect key="frame" x="117" y="8" width="32" height="32"/>
-                    <constraints>
-                        <constraint firstAttribute="width" constant="32" id="RFM-9z-asM"/>
-                        <constraint firstAttribute="height" constant="32" id="qu1-HC-myC"/>
-                    </constraints>
-                    <connections>
-                        <action selector="rightButtonTapped:" destination="-1" eventType="touchUpInside" id="M87-ng-J2b"/>
+                        <action selector="checkboxTapped:" destination="-1" eventType="touchUpInside" id="5xn-MI-IFl"/>
                     </connections>
                 </button>
             </subviews>
             <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
             <constraints>
-                <constraint firstItem="lmV-Ba-ZbW" firstAttribute="centerY" secondItem="cJx-ya-F6a" secondAttribute="centerY" id="1cC-rb-Ded"/>
+                <constraint firstAttribute="trailing" secondItem="tab-mw-4wG" secondAttribute="trailing" id="7oL-SF-lhq"/>
                 <constraint firstItem="vNJ-co-emm" firstAttribute="leading" secondItem="dhw-ue-pA7" secondAttribute="trailing" priority="750" constant="12" id="8DS-id-H6m"/>
-                <constraint firstItem="tab-mw-4wG" firstAttribute="centerY" secondItem="dhw-ue-pA7" secondAttribute="centerY" id="Pu5-dN-WP8"/>
+                <constraint firstAttribute="bottom" secondItem="tab-mw-4wG" secondAttribute="bottom" id="Nyq-NM-SSm"/>
+                <constraint firstItem="tab-mw-4wG" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="P8C-a4-d3V"/>
                 <constraint firstItem="cJx-ya-F6a" firstAttribute="centerY" secondItem="vNJ-co-emm" secondAttribute="centerY" id="QJS-dp-Xol"/>
                 <constraint firstItem="cJx-ya-F6a" firstAttribute="leading" secondItem="vNJ-co-emm" secondAttribute="trailing" priority="750" constant="12" id="Qge-6P-F47"/>
                 <constraint firstItem="vNJ-co-emm" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" constant="12" id="SiN-bV-Ca4"/>
-                <constraint firstItem="lmV-Ba-ZbW" firstAttribute="centerX" secondItem="cJx-ya-F6a" secondAttribute="centerX" id="Tuc-4F-uLx"/>
-                <constraint firstItem="tab-mw-4wG" firstAttribute="centerX" secondItem="dhw-ue-pA7" secondAttribute="centerX" id="ecH-E0-9UI"/>
                 <constraint firstAttribute="trailing" secondItem="vNJ-co-emm" secondAttribute="trailing" priority="250" constant="12" id="hp5-bY-WMe"/>
                 <constraint firstItem="dhw-ue-pA7" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="12" id="ipn-nE-ayK"/>
                 <constraint firstAttribute="bottom" secondItem="vNJ-co-emm" secondAttribute="bottom" constant="12" id="lp2-ee-WAO"/>
+                <constraint firstItem="tab-mw-4wG" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" id="nW0-i3-N6O"/>
                 <constraint firstItem="dhw-ue-pA7" firstAttribute="centerY" secondItem="vNJ-co-emm" secondAttribute="centerY" id="og3-jD-jiK"/>
                 <constraint firstAttribute="trailing" secondItem="cJx-ya-F6a" secondAttribute="trailing" constant="12" id="slR-He-nhZ"/>
                 <constraint firstItem="vNJ-co-emm" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" priority="250" constant="12" id="wyf-lI-yn5"/>


### PR DESCRIPTION
### Thanks for contributing to Andes UI!
## Description
The tappable area of the current implementation only covers the right and left checkboxes (squares), but the tappable area must to cover all the view. In other words, the checkbox and the label must to be tappable.

## Affected component
AndesCheckbox

## Screenshots / GIFs
![andes](https://user-images.githubusercontent.com/26900004/98138583-04438080-1ea2-11eb-9acb-058a19793807.gif)

## Checks
Are you sure you followed all those steps? If so, repeat after me "I solemnly swear that ...":
   - [ ] I have coded an example inside the Demo App,
   - [ ] I have added proper tests,
   - [ ] I have modified the Changelog.md file,
   - [ ] I have updated GitHub wiki,
   - [ ] I have the explicit approval of one or more members of the UX Team,
   - [ ] I have checked that this code is ObjC compliant.
   - [ ] I have checked that all the new public enums conform to AndesEnumStringConvertible.
## Change type
This is easy, let us know what this code is about:
   - [ ] This code adds a new component
   - [X] This code includes improvements to an existent component
   - [ ] This code improves or modifies ONLY the Demo App.
