### PR TITLE
[FIX] Removing scrollview from the public API

### DIFF
--- a/LibraryComponents/Classes/AndesBottomSheet/AndesBottomSheetViewController.swift
+++ b/LibraryComponents/Classes/AndesBottomSheet/AndesBottomSheetViewController.swift
@@ -32,23 +32,18 @@ open class AndesBottomSheetViewController: UIViewController {
     }
 
     @objc
-    public var scrollView: UIScrollView? {
-        get {
-            return contentController.scrollView
-        }
-        set {
-            contentController.scrollView = newValue
-            setupScrollView()
-        }
-    }
-
-    @objc
     public weak var delegate: AndesBottomSheetViewControllerDelegate?
 
     @objc
     public var titleBar: AndesBottomSheetTitleBar {
         get {
             contentController.titleBar
+        }
+    }
+
+    private var scrollView: UIScrollView? {
+        get {
+            return contentController.scrollView
         }
     }
 


### PR DESCRIPTION
### Thanks for contributing to Andes UI!
## Description

I'm removing the scrollview property from the public api. I think that as we haven't yet released this lib this can be removed without breaking changes.

After further analysis due to some helpful comments, I think that this property does more harm than good, as it adds in confusion. If it's later required we can add it again as part of the public api.

## Affected component
`AndesBottomSheetViewController`

## RFC Link
https://docs.google.com/document/d/1n6tHpPQ_9E4AEfcTM6FxYoDmsdb8bHGpdvIH0A8dC9g

## Checks
Are you sure you followed all those steps? If so, repeat after me "I solemnly swear that ...":
   - [x] I have coded an example inside the Demo App,
   - [ ] I have added proper tests,
   - [ ] I have modified the Changelog.md file,
   - [ ] I have updated GitHub wiki,
   - [x] I have the explicit approval of one or more members of the UX Team,
   - [x] I have checked that this code is ObjC compliant.
   - [x] I have checked that all the new public enums conform to AndesEnumStringConvertible.
## Change type
This is easy, let us know what this code is about:
   - [ ] This code adds a new component
   - [x] This code includes improvements to an existent component
   - [ ] This code improves or modifies ONLY the Demo App.
