### PR TITLE
AndesCheckbox Fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### 🛠 Bug fixes
 - Fixes in App Delegate and Page Controller in Test App | Authors: [@tomidelucca](https://github.com/tomidelucca)
 - AndesCheckbox tappable area extended  | Authors: [@ggiovanniniml](https://github.com/ggiovanniniml)
+- AndesCheckbox lateral padding fixed  | Authors: [@ggiovanniniml](https://github.com/ggiovanniniml)
 
 
 # v3.12.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 ### 🛠 Bug fixes
 - Fixes in App Delegate and Page Controller in Test App | Authors: [@tomidelucca](https://github.com/tomidelucca)
 - AndesCheckbox tappable area extended  | Authors: [@ggiovanniniml](https://github.com/ggiovanniniml)
-- AndesCheckbox lateral padding fixed  | Authors: [@ggiovanniniml](https://github.com/ggiovanniniml)
+- Lateral AndesCheckbox padding fixed  | Authors: [@ggiovanniniml](https://github.com/ggiovanniniml)
 
 
 # v3.12.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 ### 🛠 Bug fixes
 - Fixes in App Delegate and Page Controller in Test App | Authors: [@tomidelucca](https://github.com/tomidelucca)
 - AndesCheckbox tappable area extended  | Authors: [@ggiovanniniml](https://github.com/ggiovanniniml)
-- Lateral AndesCheckbox padding fixed  | Authors: [@ggiovanniniml](https://github.com/ggiovanniniml)
+- AndesCheckbox lateral padding fixed  | Authors: [@ggiovanniniml](https://github.com/ggiovanniniml)
 
 
 # v3.12.0

--- a/LibraryComponents/Classes/Core/AndesCheckbox/View/Default/AndesCheckboxDefaultView.xib
+++ b/LibraryComponents/Classes/Core/AndesCheckbox/View/Default/AndesCheckboxDefaultView.xib
@@ -22,17 +22,17 @@
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <view contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="iN0-l3-epB">
-            <rect key="frame" x="0.0" y="0.0" width="153" height="48"/>
+            <rect key="frame" x="0.0" y="0.0" width="130" height="48"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Checkbox" lineBreakMode="wordWrap" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vNJ-co-emm">
-                    <rect key="frame" x="40" y="12" width="73" height="24"/>
+                    <rect key="frame" x="28" y="12" width="74" height="24"/>
                     <fontDescription key="fontDescription" type="system" pointSize="16"/>
                     <nil key="textColor"/>
                     <nil key="highlightedColor"/>
                 </label>
                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="dhw-ue-pA7">
-                    <rect key="frame" x="12" y="16" width="16" height="16"/>
+                    <rect key="frame" x="0.0" y="16" width="16" height="16"/>
                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="16" id="Ttd-fb-Cjl"/>
@@ -40,7 +40,7 @@
                     </constraints>
                 </imageView>
                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="cJx-ya-F6a">
-                    <rect key="frame" x="125" y="16" width="16" height="16"/>
+                    <rect key="frame" x="114" y="16" width="16" height="16"/>
                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="16" id="Epg-cK-5Fy"/>
@@ -48,7 +48,7 @@
                     </constraints>
                 </imageView>
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="tab-mw-4wG">
-                    <rect key="frame" x="0.0" y="0.0" width="153" height="48"/>
+                    <rect key="frame" x="0.0" y="0.0" width="130" height="48"/>
                     <connections>
                         <action selector="checkboxTapped:" destination="-1" eventType="touchUpInside" id="5xn-MI-IFl"/>
                     </connections>
@@ -64,11 +64,11 @@
                 <constraint firstItem="cJx-ya-F6a" firstAttribute="leading" secondItem="vNJ-co-emm" secondAttribute="trailing" priority="750" constant="12" id="Qge-6P-F47"/>
                 <constraint firstItem="vNJ-co-emm" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" constant="12" id="SiN-bV-Ca4"/>
                 <constraint firstAttribute="trailing" secondItem="vNJ-co-emm" secondAttribute="trailing" priority="250" constant="12" id="hp5-bY-WMe"/>
-                <constraint firstItem="dhw-ue-pA7" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="12" id="ipn-nE-ayK"/>
+                <constraint firstItem="dhw-ue-pA7" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="ipn-nE-ayK"/>
                 <constraint firstAttribute="bottom" secondItem="vNJ-co-emm" secondAttribute="bottom" constant="12" id="lp2-ee-WAO"/>
                 <constraint firstItem="tab-mw-4wG" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" id="nW0-i3-N6O"/>
                 <constraint firstItem="dhw-ue-pA7" firstAttribute="centerY" secondItem="vNJ-co-emm" secondAttribute="centerY" id="og3-jD-jiK"/>
-                <constraint firstAttribute="trailing" secondItem="cJx-ya-F6a" secondAttribute="trailing" constant="12" id="slR-He-nhZ"/>
+                <constraint firstAttribute="trailing" secondItem="cJx-ya-F6a" secondAttribute="trailing" id="slR-He-nhZ"/>
                 <constraint firstItem="vNJ-co-emm" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" priority="250" constant="12" id="wyf-lI-yn5"/>
             </constraints>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>


### PR DESCRIPTION
### Thanks for contributing to Andes UI!
## Description
The current implementation has additional lateral paddings of 12pt, which should be 0pt.
This fix only removes those lateral paddings.


## Affected component
AndesCheckbox

## Screenshots / GIFs
![checkbox](https://user-images.githubusercontent.com/26900004/98568205-988d5900-228f-11eb-9dff-02d60cf28f32.gif)

### Before fix / After fix
![checkbox](https://user-images.githubusercontent.com/26900004/98568221-9cb97680-228f-11eb-8cf1-77173fb1d86a.jpg)


## Checks
Are you sure you followed all those steps? If so, repeat after me "I solemnly swear that ...":
   - [ ] I have coded an example inside the Demo App,
   - [ ] I have added proper tests,
   - [x] I have modified the Changelog.md file,
   - [ ] I have updated GitHub wiki,
   - [ ] I have the explicit approval of one or more members of the UX Team,
   - [ ] I have checked that this code is ObjC compliant.
   - [ ] I have checked that all the new public enums conform to AndesEnumStringConvertible.
## Change type
This is easy, let us know what this code is about:
   - [ ] This code adds a new component
   - [x] This code includes improvements to an existent component
   - [ ] This code improves or modifies ONLY the Demo App.
