### PR TITLE
Selection style

### DIFF
--- a/Example/AndesUI/List/View/ListObjcViewController.xib
+++ b/Example/AndesUI/List/View/ListObjcViewController.xib
@@ -1,8 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16097.3" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17126"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -18,21 +21,24 @@
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="89V-Kh-4vx" customClass="AndesList" customModule="AndesUI">
-                    <rect key="frame" x="0.0" y="0.0" width="414" height="422"/>
-                    <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
-                    <constraints>
-                        <constraint firstAttribute="width" secondItem="89V-Kh-4vx" secondAttribute="height" multiplier="207:211" id="zQb-0e-Hts"/>
-                    </constraints>
+                    <rect key="frame" x="0.0" y="44" width="414" height="759"/>
+                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                 </view>
             </subviews>
-            <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
-            <constraints>
-                <constraint firstItem="89V-Kh-4vx" firstAttribute="leading" secondItem="Q5M-cg-NOt" secondAttribute="leading" id="1CI-R0-Aj9"/>
-                <constraint firstItem="89V-Kh-4vx" firstAttribute="trailing" secondItem="Q5M-cg-NOt" secondAttribute="trailing" id="1dJ-DF-keH"/>
-                <constraint firstItem="89V-Kh-4vx" firstAttribute="top" secondItem="Q5M-cg-NOt" secondAttribute="top" id="lRw-lT-565"/>
-            </constraints>
             <viewLayoutGuide key="safeArea" id="Q5M-cg-NOt"/>
+            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+            <constraints>
+                <constraint firstItem="Q5M-cg-NOt" firstAttribute="bottom" secondItem="89V-Kh-4vx" secondAttribute="bottom" constant="59" id="8xs-V8-ISv"/>
+                <constraint firstItem="89V-Kh-4vx" firstAttribute="top" secondItem="Q5M-cg-NOt" secondAttribute="top" id="Aaq-Nq-D3R"/>
+                <constraint firstItem="89V-Kh-4vx" firstAttribute="leading" secondItem="Q5M-cg-NOt" secondAttribute="leading" id="Ii0-ur-ssK"/>
+                <constraint firstItem="89V-Kh-4vx" firstAttribute="trailing" secondItem="Q5M-cg-NOt" secondAttribute="trailing" id="O8c-hM-ISz"/>
+            </constraints>
             <point key="canvasLocation" x="137.68115942028987" y="120.53571428571428"/>
         </view>
     </objects>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
 </document>

--- a/Example/AndesUI/List/View/ListViewController.swift
+++ b/Example/AndesUI/List/View/ListViewController.swift
@@ -17,7 +17,7 @@ class ListViewController: UIViewController {
     @IBOutlet weak var radioButtonIcon: AndesRadioButton!
     @IBOutlet weak var radioButtonThumbnail: AndesRadioButton!
     @IBOutlet weak var titleTxt: AndesTextField!
-    @IBOutlet weak var numberOfLinesTitle: UITextField!
+    @IBOutlet weak var numberOfLinesTitle: AndesTextField!
     @IBOutlet weak var descriptionTxt: AndesTextField!
     @IBOutlet weak var selection: UISegmentedControl!
 
@@ -41,6 +41,7 @@ class ListViewController: UIViewController {
         andesList.delegate = self
         andesList.dataSource = self
         andesList.separatorStyle = .singleLine
+        andesList.selectionStyle = .defaultStyle
 
         self.setValuesDefault()
     }
@@ -113,7 +114,7 @@ class ListViewController: UIViewController {
     }
 
     func getNumberOfLines() -> Int {
-        if let lines = Int(self.numberOfLinesTitle.text ?? "0") {
+        if let lines = Int(self.numberOfLinesTitle.text) {
             return lines
         }
         return 0

--- a/Example/AndesUI/List/View/ListViewController.xib
+++ b/Example/AndesUI/List/View/ListViewController.xib
@@ -13,7 +13,7 @@
             <connections>
                 <outlet property="andesList" destination="e1M-cg-BO9" id="rQF-SK-3tf"/>
                 <outlet property="descriptionTxt" destination="X5o-bZ-wtE" id="BDK-YW-yKF"/>
-                <outlet property="numberOfLinesTitle" destination="ovC-fa-d7d" id="4IX-EC-NBI"/>
+                <outlet property="numberOfLinesTitle" destination="nqV-M3-a9O" id="wH0-oF-fpd"/>
                 <outlet property="radioButtonChevron" destination="kq9-IH-nlE" id="yoi-nd-fPy"/>
                 <outlet property="radioButtonIcon" destination="QXn-dg-Twr" id="Lq3-kk-UaQ"/>
                 <outlet property="radioButtonSimple" destination="hkB-1q-Uk8" id="b0g-6S-WY0"/>
@@ -29,11 +29,14 @@
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <subviews>
                 <view contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" translatesAutoresizingMaskIntoConstraints="NO" id="e1M-cg-BO9" customClass="AndesList" customModule="AndesUI">
-                    <rect key="frame" x="0.0" y="342" width="375" height="377"/>
+                    <rect key="frame" x="0.0" y="434" width="375" height="285"/>
                     <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                 </view>
                 <segmentedControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="1" translatesAutoresizingMaskIntoConstraints="NO" id="4LV-i7-NTA">
-                    <rect key="frame" x="39" y="59" width="297" height="32"/>
+                    <rect key="frame" x="39" y="103" width="297" height="32"/>
+                    <constraints>
+                        <constraint firstAttribute="height" constant="31" id="8Sw-rj-muY"/>
+                    </constraints>
                     <segments>
                         <segment title="Small"/>
                         <segment title="Medium"/>
@@ -44,7 +47,7 @@
                     </connections>
                 </segmentedControl>
                 <stackView opaque="NO" contentMode="scaleToFill" distribution="fillProportionally" spacing="6" translatesAutoresizingMaskIntoConstraints="NO" id="gMT-PO-lnQ">
-                    <rect key="frame" x="86" y="283" width="204" height="35"/>
+                    <rect key="frame" x="86" y="391" width="204" height="35"/>
                     <subviews>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="CWa-CE-1mS" customClass="AndesButton" customModule="AndesUI">
                             <rect key="frame" x="0.0" y="0.0" width="99" height="35"/>
@@ -75,13 +78,13 @@
                     </constraints>
                 </stackView>
                 <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="qds-fC-qas">
-                    <rect key="frame" x="43" y="98" width="288" height="101"/>
+                    <rect key="frame" x="43" y="142" width="288" height="101"/>
                     <subviews>
                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" spacing="1" translatesAutoresizingMaskIntoConstraints="NO" id="lQz-zh-ivX">
-                            <rect key="frame" x="0.0" y="0.0" width="140" height="101"/>
+                            <rect key="frame" x="0.0" y="0.0" width="135" height="101"/>
                             <subviews>
                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="hkB-1q-Uk8" customClass="AndesRadioButton" customModule="AndesUI">
-                                    <rect key="frame" x="0.0" y="0.0" width="140" height="50"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="135" height="50"/>
                                     <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                     <userDefinedRuntimeAttributes>
                                         <userDefinedRuntimeAttribute type="string" keyPath="title" value="Simple"/>
@@ -90,7 +93,7 @@
                                     </userDefinedRuntimeAttributes>
                                 </view>
                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="kq9-IH-nlE" customClass="AndesRadioButton" customModule="AndesUI">
-                                    <rect key="frame" x="0.0" y="51" width="140" height="50"/>
+                                    <rect key="frame" x="0.0" y="51" width="135" height="50"/>
                                     <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                     <userDefinedRuntimeAttributes>
                                         <userDefinedRuntimeAttribute type="string" keyPath="title" value="Chevron"/>
@@ -99,11 +102,19 @@
                                 </view>
                             </subviews>
                         </stackView>
+                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="qBg-T1-EkH">
+                            <rect key="frame" x="143" y="0.0" width="2" height="101"/>
+                            <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                            <constraints>
+                                <constraint firstAttribute="height" constant="101" id="4JJ-Kt-f6d"/>
+                                <constraint firstAttribute="width" constant="2" id="L1V-qE-x9V"/>
+                            </constraints>
+                        </view>
                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" spacing="1" translatesAutoresizingMaskIntoConstraints="NO" id="4cM-Ra-0hb">
-                            <rect key="frame" x="148" y="0.0" width="140" height="101"/>
+                            <rect key="frame" x="153" y="0.0" width="135" height="101"/>
                             <subviews>
                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="QXn-dg-Twr" customClass="AndesRadioButton" customModule="AndesUI">
-                                    <rect key="frame" x="0.0" y="0.0" width="140" height="50"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="135" height="50"/>
                                     <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                     <userDefinedRuntimeAttributes>
                                         <userDefinedRuntimeAttribute type="string" keyPath="title" value="Icon"/>
@@ -111,7 +122,7 @@
                                     </userDefinedRuntimeAttributes>
                                 </view>
                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="0X0-tL-FSM" customClass="AndesRadioButton" customModule="AndesUI">
-                                    <rect key="frame" x="0.0" y="51" width="140" height="50"/>
+                                    <rect key="frame" x="0.0" y="51" width="135" height="50"/>
                                     <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                     <userDefinedRuntimeAttributes>
                                         <userDefinedRuntimeAttribute type="string" keyPath="title" value="Thumbnail"/>
@@ -122,35 +133,60 @@
                         </stackView>
                     </subviews>
                     <constraints>
-                        <constraint firstAttribute="trailing" secondItem="lQz-zh-ivX" secondAttribute="trailing" constant="148" id="6eX-n8-1aq"/>
                         <constraint firstAttribute="width" secondItem="qds-fC-qas" secondAttribute="height" multiplier="288:101" id="CqS-Wt-ic2"/>
+                        <constraint firstItem="qBg-T1-EkH" firstAttribute="centerY" secondItem="qds-fC-qas" secondAttribute="centerY" id="u2e-hM-qEt"/>
+                        <constraint firstItem="qBg-T1-EkH" firstAttribute="centerX" secondItem="qds-fC-qas" secondAttribute="centerX" id="x5h-ey-BdO"/>
                     </constraints>
                 </stackView>
-                <stackView opaque="NO" contentMode="scaleToFill" spacing="3" translatesAutoresizingMaskIntoConstraints="NO" id="1pv-p7-Px1">
-                    <rect key="frame" x="43" y="206" width="288" height="35"/>
+                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="tUk-30-IJQ">
+                    <rect key="frame" x="43" y="260" width="288" height="70.333333333333314"/>
                     <subviews>
-                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="8dA-25-TgZ" customClass="AndesTextField" customModule="AndesUI">
-                            <rect key="frame" x="0.0" y="0.0" width="242" height="35"/>
-                            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="yBp-Tm-oEj">
+                            <rect key="frame" x="0.0" y="0.0" width="288" height="20"/>
+                            <subviews>
+                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" text="Título" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ilf-BT-Tei">
+                                    <rect key="frame" x="0.0" y="0.0" width="168.66666666666666" height="20"/>
+                                    <fontDescription key="fontDescription" type="system" pointSize="15"/>
+                                    <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                    <nil key="highlightedColor"/>
+                                </label>
+                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Número de líneas" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="jqy-IB-q1s">
+                                    <rect key="frame" x="168.66666666666666" y="0.0" width="119.33333333333334" height="20"/>
+                                    <fontDescription key="fontDescription" type="system" pointSize="15"/>
+                                    <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                    <nil key="highlightedColor"/>
+                                </label>
+                            </subviews>
                             <constraints>
-                                <constraint firstAttribute="height" constant="35" id="6a0-2M-nOk"/>
+                                <constraint firstAttribute="height" constant="20" id="NGa-aj-Sxu"/>
                             </constraints>
-                        </view>
-                        <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="0" borderStyle="roundedRect" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="ovC-fa-d7d">
-                            <rect key="frame" x="245" y="0.0" width="43" height="35"/>
-                            <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                            <textInputTraits key="textInputTraits" keyboardType="numberPad"/>
-                        </textField>
+                        </stackView>
+                        <stackView opaque="NO" contentMode="scaleToFill" spacing="3" translatesAutoresizingMaskIntoConstraints="NO" id="1pv-p7-Px1">
+                            <rect key="frame" x="0.0" y="20.000000000000004" width="288" height="50.333333333333343"/>
+                            <subviews>
+                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="8dA-25-TgZ" customClass="AndesTextField" customModule="AndesUI">
+                                    <rect key="frame" x="0.0" y="0.0" width="235" height="50.333333333333336"/>
+                                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                </view>
+                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="nqV-M3-a9O" customClass="AndesTextField" customModule="AndesUI">
+                                    <rect key="frame" x="238" y="0.0" width="50" height="50.333333333333336"/>
+                                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                </view>
+                            </subviews>
+                            <constraints>
+                                <constraint firstItem="nqV-M3-a9O" firstAttribute="leading" secondItem="1pv-p7-Px1" secondAttribute="leading" constant="238" id="DCj-2E-SIH"/>
+                            </constraints>
+                        </stackView>
                     </subviews>
                     <constraints>
-                        <constraint firstAttribute="trailing" secondItem="8dA-25-TgZ" secondAttribute="trailing" constant="46" id="Drv-m6-qZT"/>
+                        <constraint firstAttribute="height" constant="70.329999999999998" id="AYb-aF-o5M"/>
                     </constraints>
                 </stackView>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="X5o-bZ-wtE" customClass="AndesTextField" customModule="AndesUI">
-                    <rect key="frame" x="43" y="243" width="288" height="35"/>
+                    <rect key="frame" x="43" y="334" width="288" height="50"/>
                     <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                     <constraints>
-                        <constraint firstAttribute="height" constant="35" id="mbl-S5-oYT"/>
+                        <constraint firstAttribute="height" constant="50" id="mbl-S5-oYT"/>
                     </constraints>
                 </view>
             </subviews>
@@ -159,23 +195,24 @@
                 <constraint firstItem="elp-bJ-LVV" firstAttribute="bottom" secondItem="e1M-cg-BO9" secondAttribute="bottom" constant="59" id="52d-3C-ZE7"/>
                 <constraint firstItem="qds-fC-qas" firstAttribute="top" secondItem="4LV-i7-NTA" secondAttribute="bottom" constant="8" symbolic="YES" id="631-3T-qdN"/>
                 <constraint firstItem="elp-bJ-LVV" firstAttribute="trailing" secondItem="qds-fC-qas" secondAttribute="trailing" constant="44" id="8a7-D8-Njo"/>
-                <constraint firstItem="elp-bJ-LVV" firstAttribute="trailing" secondItem="1pv-p7-Px1" secondAttribute="trailing" constant="44" id="HQ1-Af-OWC"/>
-                <constraint firstItem="1pv-p7-Px1" firstAttribute="top" secondItem="qds-fC-qas" secondAttribute="bottom" constant="7" id="Ife-iu-o93"/>
                 <constraint firstItem="elp-bJ-LVV" firstAttribute="trailing" secondItem="X5o-bZ-wtE" secondAttribute="trailing" constant="44" id="Jfg-m7-tZ9"/>
                 <constraint firstItem="4LV-i7-NTA" firstAttribute="leading" secondItem="elp-bJ-LVV" secondAttribute="leading" constant="39" id="MN0-n8-1jh"/>
-                <constraint firstItem="gMT-PO-lnQ" firstAttribute="top" secondItem="X5o-bZ-wtE" secondAttribute="bottom" constant="5" id="PLh-dS-lOR"/>
-                <constraint firstItem="1pv-p7-Px1" firstAttribute="leading" secondItem="elp-bJ-LVV" secondAttribute="leading" constant="43" id="RMl-3Y-CUa"/>
                 <constraint firstItem="X5o-bZ-wtE" firstAttribute="leading" secondItem="elp-bJ-LVV" secondAttribute="leading" constant="43" id="SdE-bZ-rVo"/>
                 <constraint firstItem="gMT-PO-lnQ" firstAttribute="leading" secondItem="elp-bJ-LVV" secondAttribute="leading" constant="86" id="UQf-1f-Gdo"/>
                 <constraint firstItem="elp-bJ-LVV" firstAttribute="trailing" secondItem="gMT-PO-lnQ" secondAttribute="trailing" constant="85" id="Ulj-Oz-IKr"/>
-                <constraint firstItem="X5o-bZ-wtE" firstAttribute="top" secondItem="1pv-p7-Px1" secondAttribute="bottom" constant="2" id="XwF-u2-mEw"/>
+                <constraint firstItem="tUk-30-IJQ" firstAttribute="top" secondItem="qds-fC-qas" secondAttribute="bottom" constant="17" id="aM5-tr-ozZ"/>
+                <constraint firstItem="tUk-30-IJQ" firstAttribute="leading" secondItem="elp-bJ-LVV" secondAttribute="leading" constant="43" id="aSp-nO-c6W"/>
                 <constraint firstItem="e1M-cg-BO9" firstAttribute="trailing" secondItem="elp-bJ-LVV" secondAttribute="trailing" id="d9a-qw-Dr0"/>
                 <constraint firstItem="4LV-i7-NTA" firstAttribute="top" secondItem="elp-bJ-LVV" secondAttribute="top" constant="15" id="dfi-mn-Fbd"/>
-                <constraint firstItem="e1M-cg-BO9" firstAttribute="top" secondItem="gMT-PO-lnQ" secondAttribute="bottom" constant="24" id="eco-za-Gxx"/>
+                <constraint firstItem="e1M-cg-BO9" firstAttribute="top" secondItem="gMT-PO-lnQ" secondAttribute="bottom" constant="8" id="eco-za-Gxx"/>
+                <constraint firstItem="X5o-bZ-wtE" firstAttribute="top" secondItem="tUk-30-IJQ" secondAttribute="bottom" constant="3.6666666666666856" id="gAv-6b-GBp"/>
                 <constraint firstItem="qds-fC-qas" firstAttribute="leading" secondItem="elp-bJ-LVV" secondAttribute="leading" constant="43" id="jlg-hB-vUr"/>
+                <constraint firstItem="gMT-PO-lnQ" firstAttribute="top" secondItem="X5o-bZ-wtE" secondAttribute="bottom" constant="7" id="lcK-36-xuf"/>
+                <constraint firstItem="elp-bJ-LVV" firstAttribute="trailing" secondItem="tUk-30-IJQ" secondAttribute="trailing" constant="44" id="piP-8p-k0Y"/>
                 <constraint firstItem="elp-bJ-LVV" firstAttribute="trailing" secondItem="4LV-i7-NTA" secondAttribute="trailing" constant="39" id="qlE-IT-jhX"/>
                 <constraint firstItem="e1M-cg-BO9" firstAttribute="leading" secondItem="elp-bJ-LVV" secondAttribute="leading" id="zBj-uU-1Dk"/>
             </constraints>
+            <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" barStyle="black" prompted="NO"/>
             <point key="canvasLocation" x="-7.2000000000000002" y="5.9113300492610836"/>
         </view>
     </objects>

--- a/Example/Tests/AndesListTests.swift
+++ b/Example/Tests/AndesListTests.swift
@@ -319,6 +319,58 @@ class AndesListTests: QuickSpec {
                     //Then
                     expect(self.internalAndesList?.getSeparatorStyle()).to(equal(style))
                 }
+
+                it("Check selection Style gray color") {
+                    //Given
+                    self.internalAndesList?.listType = "simple"
+                    self.cellType = .chevron
+                    self.thumbnailType = .icon
+
+                    //When
+                    self.internalAndesList?.selectionStyle = .gray
+
+                    //Then
+                    expect(self.internalAndesList?.getSelectionStyle()).to(equal(UITableViewCell.SelectionStyle.gray))
+                }
+
+                it("Check selection Style blue color") {
+                    //Given
+                    self.internalAndesList?.listType = "simple"
+                    self.cellType = .chevron
+                    self.thumbnailType = .icon
+
+                    //When
+                    self.internalAndesList?.selectionStyle = .blue
+
+                    //Then
+                    expect(self.internalAndesList?.getSelectionStyle()).to(equal(UITableViewCell.SelectionStyle.blue))
+                }
+
+                it("Check selection Style default color") {
+                    //Given
+                    self.internalAndesList?.listType = "simple"
+                    self.cellType = .chevron
+                    self.thumbnailType = .icon
+
+                    //When
+                    self.internalAndesList?.selectionStyle = .defaultStyle
+
+                    //Then
+                    expect(self.internalAndesList?.getSelectionStyle()).to(equal(UITableViewCell.SelectionStyle.default))
+                }
+
+                it("Check selection Style none color") {
+                    //Given
+                    self.internalAndesList?.listType = "simple"
+                    self.cellType = .chevron
+                    self.thumbnailType = .icon
+
+                    //When
+                    self.internalAndesList?.selectionStyle = .none
+
+                    //Then
+                    expect(self.internalAndesList?.getSelectionStyle()).to(equal(UITableViewCell.SelectionStyle.none))
+                }
             }
         }
     }
@@ -369,14 +421,6 @@ extension AndesListTests: AndesListProtocol {
         return 1
     }
 
-//    func andesList(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-//        return self.andesList(self.internalAndesList!, numberOfRowsInSection: section)
-//    }
-//
-//    func numberOfSections(in tableView: UITableView) -> Int {
-//        return self.numberOfSections(in: tableView)
-//    }
-
     func cellForRowAt(indexPath: IndexPath) -> AndesListCell {
         let customCell = self.andesList(self.internalAndesList!, cellForRowAt: indexPath)
         return customCell
@@ -388,5 +432,9 @@ extension AndesListTests: AndesListProtocol {
 
     func didSelectRowAt(indexPath: IndexPath) {
         self.didSelected = true
+    }
+
+    func getSelectionStyle() -> UITableViewCell.SelectionStyle {
+        return .gray
     }
 }

--- a/LibraryComponents/Classes/Core/AndesList/AndesList.swift
+++ b/LibraryComponents/Classes/Core/AndesList/AndesList.swift
@@ -18,6 +18,9 @@ import Foundation
     /// Set the separator style, default value .none
     @objc public var separatorStyle: AndesSeparatorStyle = .none
 
+    /// Set the selection style, default value .default
+    @objc public var selectionStyle: AndesSelectionStyle = .defaultStyle
+
     /// Set the list type, default value simple
     @IBInspectable public var listType: String {
         get {
@@ -98,5 +101,18 @@ extension AndesList: AndesListProtocol {
 
     func didSelectRowAt(indexPath: IndexPath) {
         self.delegate?.andesList?(self, didSelectRowAt: indexPath)
+    }
+
+    func getSelectionStyle() -> UITableViewCell.SelectionStyle {
+        switch selectionStyle {
+        case .none:
+            return .none
+        case .blue:
+            return .blue
+        case .gray:
+            return .gray
+        case .defaultStyle:
+            return .default
+        }
     }
 }

--- a/LibraryComponents/Classes/Core/AndesList/InternalDelegates/AndesListTableViewDataSource.swift
+++ b/LibraryComponents/Classes/Core/AndesList/InternalDelegates/AndesListTableViewDataSource.swift
@@ -31,12 +31,14 @@ internal class AndesListTableViewDataSource: NSObject, UITableViewDataSource {
             guard let cell = tableView.dequeueReusableCell(withIdentifier: "AndesListSimpleViewCell", for: indexPath) as? AndesListSimpleViewCell else {
                 fatalError("The dequeued cell is not an instance of AndesListSimpleViewCell.")
             }
+            cell.selectionStyle = listProtocol.getSelectionStyle()
             cell.display(indexPath: indexPath, customCell: customCell, separatorStyle: listProtocol.getSeparatorStyle())
             return cell
         case .chevron:
             guard let cell = tableView.dequeueReusableCell(withIdentifier: "AndesListChevronViewCell", for: indexPath) as? AndesListChevronViewCell else {
                 fatalError("The dequeued cell is not an instance of AndesListChevronViewCell.")
             }
+            cell.selectionStyle = listProtocol.getSelectionStyle()
             cell.display(indexPath: indexPath, customCell: customCell, separatorStyle: listProtocol.getSeparatorStyle())
             return cell
         default:

--- a/LibraryComponents/Classes/Core/AndesList/InternalDelegates/Protocols/AndesListProtocol.swift
+++ b/LibraryComponents/Classes/Core/AndesList/InternalDelegates/Protocols/AndesListProtocol.swift
@@ -12,5 +12,6 @@ import Foundation
     func numberOfSections(in tableView: UITableView) -> Int
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int
     func getSeparatorStyle() -> AndesSeparatorStyle
+    func getSelectionStyle() -> UITableViewCell.SelectionStyle
     @objc optional func didSelectRowAt(indexPath: IndexPath)
 }

--- a/LibraryComponents/Classes/Core/AndesList/Style/AndesSelectionStyle.swift
+++ b/LibraryComponents/Classes/Core/AndesList/Style/AndesSelectionStyle.swift
@@ -1,0 +1,24 @@
+//
+//  AndesSelectionStyle.swift
+//  AndesUI
+//
+//  Created by Jonathan Alonso Pinto on 9/11/20.
+//
+
+import Foundation
+
+@objc public enum AndesSelectionStyle: Int, AndesEnumStringConvertible {
+    case gray
+    case blue
+    case none
+    case defaultStyle
+
+    public static func keyFor(_ value: AndesSelectionStyle) -> String {
+        switch value {
+        case .none: return "none"
+        case .gray: return "gray"
+        case .blue: return "blue"
+        case .defaultStyle: return "default"
+        }
+    }
+}


### PR DESCRIPTION
### Thanks for contributing to Andes UI!
## Description
Se implementa la opción para que el dev pueda cambiar el efecto de selección de una celda
## Affected component
N/A
## RFC Link
https://docs.google.com/document/d/1lsJ_Oz-XplkwAMbINjTSdz8imvVDUqIbElZZNKsUo5Q/edit#
## Screenshots / GIFs

<img width="584" alt="Captura de Pantalla 2020-11-09 a la(s) 4 15 44 p  m" src="https://user-images.githubusercontent.com/69221534/98601484-1dd33680-22ad-11eb-9b1f-635c2cd8be54.png">


## Checks
Are you sure you followed all those steps? If so, repeat after me "I solemnly swear that ...":
   - [] I have coded an example inside the Demo App,
   - [x] I have added proper tests,
   - [ ] I have modified the Changelog.md file,
   - [ ] I have updated GitHub wiki,
   - [ ] I have the explicit approval of one or more members of the UX Team,
   - [ ] I have checked that this code is ObjC compliant.
   - [x] I have checked that all the new public enums conform to AndesEnumStringConvertible.
## Change type
This is easy, let us know what this code is about:
   - [ ] This code adds a new component
   - [x] This code includes improvements to an existent component
   - [ ] This code improves or modifies ONLY the Demo App.
