### PR TITLE
Change buttonColor in Tag Choice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Unpublished
+### 🛠 Bug fixes
+- AndesTagChoice text color changed. | Authors: [@JBAZANCARRIZ](https://github.com/JBAZANCARRIZ)
 ### 🚀 Features
 - New component AndesList | Authors: [@joalonsopint](https://github.com/joalonsopint)
 - Adding accessibility to AndesListCell componente | Authors: [@joalonsopint](https://github.com/joalonsopint)

--- a/LibraryComponents/Classes/Core/AndesTag/State/AndesTagStateIdle.swift
+++ b/LibraryComponents/Classes/Core/AndesTag/State/AndesTagStateIdle.swift
@@ -13,7 +13,7 @@ struct AndesTagStateIdle: AndesTagStateProtocol {
 
     var borderColor: UIColor = UIColor.Andes.gray250
 
-    var buttonColor: UIColor = UIColor.Andes.gray450
+    var buttonColor: UIColor = UIColor.Andes.gray800
 
     var backgroundColor: UIColor = UIColor.clear
 


### PR DESCRIPTION
### Thanks for contributing to Andes UI!
## Description
ButtonColor is changed so that it has the same as the text
Try to answer these questions:
- What is it about?
- How does it work?
## Affected component
Tag Choice
## RFC Link
If this change was discussed on RFC please paste link here.
## Screenshots / GIFs
<img width="340" alt="Captura de Pantalla 2020-11-17 a la(s) 9 56 32 a  m" src="https://user-images.githubusercontent.com/63874225/99392885-36e67380-28bb-11eb-9229-96c2696f1bc5.png">

## Checks
Are you sure you followed all those steps? If so, repeat after me "I solemnly swear that ...":
   - [ ] I have coded an example inside the Demo App,
   - [ ] I have added proper tests,
   - [ ] I have modified the Changelog.md file,
   - [ ] I have updated GitHub wiki,
   - [ ] I have the explicit approval of one or more members of the UX Team,
   - [ ] I have checked that this code is ObjC compliant.
   - [ ] I have checked that all the new public enums conform to AndesEnumStringConvertible.
## Change type
This is easy, let us know what this code is about:
   - [ ] This code adds a new component
   - [ ] This code includes improvements to an existent component
   - [ ] This code improves or modifies ONLY the Demo App.
