### PR TITLE
Fix removing cell size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ### 🛠 Bug fixes
 - AndesTagChoice text color changed. | Authors: [@JBAZANCARRIZ](https://github.com/JBAZANCARRIZ)
 - AndesList fix border in thumbnail | Authors: [@joalonsopint](https://github.com/joalonsopint)
+- AndesList fix removing cell size | Authors: [@joalonsopint](https://github.com/joalonsopint)
 
 ### 🚀 Features
 - Date Picker component | Authors: [@AndriuCoelho](https://github.com/AndriuCoelho)

--- a/Example/AndesUI/List/View/ListObjcViewController.m
+++ b/Example/AndesUI/List/View/ListObjcViewController.m
@@ -22,28 +22,27 @@
     _listView.delegate = self;
     _listView.dataSource = self;
     _listView.separatorStyle = AndesSeparatorStyleSingleLine;
+    _listView.size = AndesListSizeLarge;
 }
 
 - (AndesListCell * _Nonnull)andesList:(AndesList * _Nonnull)tableView cellForRowAt:(NSIndexPath * _Nonnull)indexPath {
     
-    AndesThumbnail *thumbnail = [[AndesThumbnail alloc]initWithHierarchy:AndesThumbnailHierarchyLoud
+    AndesThumbnail *thumbnail = [[AndesThumbnail alloc]initWithHierarchy:AndesThumbnailHierarchyDefaultHierarchy
                                                                     type:AndesThumbnailTypeIcon
                                                                     size:AndesThumbnailSizeSize24
                                                                    state:AndesThumbnailStateEnabled
-                                                                   image:[UIImage imageNamed:@"andes"]
-                                                             accentColor:[UIColor clearColor]];
+                                                                   image:[UIImage imageNamed:@"clip"]
+                                                             accentColor:NULL];
     
     AndesSimpleCell *cell = [[AndesSimpleCell alloc]
                              initWithTitle:[NSString
                                             stringWithFormat:@"Lorem ipsum dolor sit amet title - %ld", (long)indexPath.row]
-                             size:AndesListSizeLarge
                              subtitle: @"Lorem ipsum dolor sit amet description"
                              thumbnail: thumbnail
                              numberOfLines: 2];
     
     AndesChevronCell *chevronCell = [[AndesChevronCell alloc]initWithTitle:[NSString
                                                                             stringWithFormat:@"Lorem ipsum dolor sit amet title - %ld", (long)indexPath.row]
-                                                                      size:AndesListSizeMedium
                                                                   subtitle:@"Lorem ipsum dolor sit amet subtitle"
                                                                  thumbnail:thumbnail
                                                              numberOfLines: 0];

--- a/Example/AndesUI/List/View/ListViewController.swift
+++ b/Example/AndesUI/List/View/ListViewController.swift
@@ -24,7 +24,6 @@ class ListViewController: UIViewController {
     let icon = AndesThumbnail(hierarchy: .defaultHierarchy, type: .icon, size: .size24, state: .enabled, image: UIImage(named: "clip") ?? UIImage(), accentColor: UIColor.clear)
     let thumbnail = AndesThumbnail(hierarchy: .defaultHierarchy, type: .imageCircle, size: .size24, state: .enabled, image: UIImage(named: "clip") ?? UIImage(), accentColor: UIColor.clear)
     var cell: AndesListCell!
-    var size: AndesListSize?
     var image: AndesThumbnail?
     var numberOfLines: Int?
 
@@ -43,6 +42,7 @@ class ListViewController: UIViewController {
         andesList.separatorStyle = .singleLine
         andesList.selectionStyle = .defaultStyle
         andesList.listType = .simple
+        andesList.size = .medium
 
         self.setValuesDefault()
     }
@@ -55,10 +55,11 @@ class ListViewController: UIViewController {
     @IBAction func setValuesDefault() {
         self.titleTxt.text = "list.label.titleCell".localized
         self.descriptionTxt.text = "list.label.subTitleCell".localized
-        self.size = .medium
+        andesList.size = .medium
         self.image = nil
         self.numberOfLines = 0
         andesList.listType = .simple
+        andesList.size = .medium
         simpleCellSelected = true
         selection.selectedSegmentIndex = 1
         self.numberOfLinesTitle.text = "0"
@@ -94,13 +95,11 @@ class ListViewController: UIViewController {
     func buildCell() {
         if simpleCellSelected {
             cell = AndesSimpleCell(withTitle: getTitleRow(),
-                                   size: self.size,
                                    subtitle: self.descriptionTxt.text,
                                    thumbnail: self.image,
                                    numberOfLines: self.getNumberOfLines())
         } else {
             cell = AndesChevronCell(withTitle: getTitleRow(),
-                                    size: self.size,
                                     subtitle: self.descriptionTxt.text,
                                     thumbnail: self.image,
                                     numberOfLines: self.getNumberOfLines())
@@ -123,11 +122,11 @@ class ListViewController: UIViewController {
 
     @IBAction func valueChangeSegmented() {
         if selection.selectedSegmentIndex == 0 {
-            size = .small
+            andesList.size = .small
         } else if selection.selectedSegmentIndex == 1 {
-            size = .medium
+            andesList.size = .medium
         } else {
-            size = .large
+            andesList.size = .large
         }
     }
 

--- a/Example/Tests/AndesListTests.swift
+++ b/Example/Tests/AndesListTests.swift
@@ -19,6 +19,7 @@ class AndesListTests: QuickSpec {
     var didSelected: Bool = false
     var icon: AndesThumbnail?
     var thumbnail: AndesThumbnail?
+    var size: AndesListSize?
 
     override func spec() {
         describe("AndesList should draw it's view based on style and size") {
@@ -31,11 +32,9 @@ class AndesListTests: QuickSpec {
                 it("Has the right simple cell view medium type with icon") {
                     //Given
                     let simplecell = AndesSimpleCell(withTitle: "Title",
-                                                         size: .medium,
                                                          subtitle: "Sub title")
 
                     let chevronCell = AndesChevronCell(withTitle: "Title",
-                                                          size: .medium,
                                                           subtitle: "Descripción de la celda",
                                                           thumbnail: self.icon)
 
@@ -49,11 +48,9 @@ class AndesListTests: QuickSpec {
                 it("Has the right simple cell view small type with icon") {
                     //Given
                     let simplecell = AndesSimpleCell(withTitle: "Title",
-                                                         size: .small,
                                                          subtitle: "Sub title")
 
                     let chevronCell = AndesChevronCell(withTitle: "Title",
-                                                          size: .small,
                                                           subtitle: "Descripción de la celda",
                                                           thumbnail: self.icon)
 
@@ -67,11 +64,9 @@ class AndesListTests: QuickSpec {
                 it("Has the right simple cell view large type with icon") {
                     //Given
                     let simplecell = AndesSimpleCell(withTitle: "Title",
-                                                         size: .large,
                                                          subtitle: "Sub title")
 
                     let chevronCell = AndesChevronCell(withTitle: "Title",
-                                                          size: .large,
                                                           subtitle: "Descripción de la celda",
                                                           thumbnail: self.icon)
 
@@ -85,11 +80,9 @@ class AndesListTests: QuickSpec {
                 it("Has the right simple cell view medium type with image circle") {
                     //Given
                     let simplecell = AndesSimpleCell(withTitle: "Title",
-                                                         size: .medium,
                                                          subtitle: "Sub title")
 
                     let chevronCell = AndesChevronCell(withTitle: "Title",
-                                                          size: .medium,
                                                           subtitle: "Descripción de la celda",
                                                           thumbnail: self.thumbnail)
 
@@ -103,11 +96,9 @@ class AndesListTests: QuickSpec {
                 it("Has the right simple cell view small type with image circle") {
                     //Given
                     let simplecell = AndesSimpleCell(withTitle: "Title",
-                                                         size: .small,
                                                          subtitle: "Sub title")
 
                     let chevronCell = AndesChevronCell(withTitle: "Title",
-                                                          size: .small,
                                                           subtitle: "Descripción de la celda",
                                                           thumbnail: self.thumbnail)
 
@@ -121,11 +112,9 @@ class AndesListTests: QuickSpec {
                 it("Has the right simple cell view large type with image circle") {
                     //Given
                     let simplecell = AndesSimpleCell(withTitle: "Title",
-                                                         size: .large,
                                                          subtitle: "Sub title")
 
                     let chevronCell = AndesChevronCell(withTitle: "Title",
-                                                          size: .large,
                                                           subtitle: "Descripción de la celda",
                                                           thumbnail: self.thumbnail)
 
@@ -177,6 +166,7 @@ class AndesListTests: QuickSpec {
                 it("Check cellForRowAt delegate with simple cell without icon in TableView") {
                     //Given
                     self.internalAndesList?.listType = .simple
+                    self.internalAndesList?.size = .small
                     self.cellType = .simple
                     let table = UITableView()
                     table.dataSource = myDataSource
@@ -195,6 +185,7 @@ class AndesListTests: QuickSpec {
                 it("Check cellForRowAt delegate with simple cell and icon in TableView") {
                     //Given
                     self.internalAndesList?.listType = .simple
+                    self.internalAndesList?.size = .medium
                     self.cellType = .simple
                     self.thumbnailType = .icon
                     let table = UITableView()
@@ -214,6 +205,7 @@ class AndesListTests: QuickSpec {
                 it("Check cellForRowAt delegate with chevron cell and icon in TableView") {
                     //Given
                     self.internalAndesList?.listType = .chevron
+                    self.internalAndesList?.size = .large
                     self.cellType = .chevron
                     self.thumbnailType = .icon
                     let table = UITableView()
@@ -232,6 +224,7 @@ class AndesListTests: QuickSpec {
                 it("Check cellForRowAt delegate with simple cell and ImageCircle in TableView") {
                     //Given
                     self.internalAndesList?.listType = .simple
+                    self.internalAndesList?.size = .small
                     self.cellType = .simple
                     self.thumbnailType = .imageCircle
                     let table = UITableView()
@@ -251,6 +244,7 @@ class AndesListTests: QuickSpec {
                 it("Check cellForRowAt delegate with chevron cell and ImageCircle in TableView") {
                     //Given
                     self.internalAndesList?.listType = .chevron
+                    self.internalAndesList?.size = .medium
                     self.cellType = .chevron
                     self.thumbnailType = .imageCircle
                     let table = UITableView()
@@ -309,6 +303,7 @@ class AndesListTests: QuickSpec {
                 it("Check separator Style") {
                     //Given
                     self.internalAndesList?.listType = .chevron
+                    self.internalAndesList?.size = .small
                     self.cellType = .chevron
                     self.thumbnailType = .icon
                     let style = AndesSeparatorStyle.none
@@ -323,6 +318,7 @@ class AndesListTests: QuickSpec {
                 it("Check selection Style gray color") {
                     //Given
                     self.internalAndesList?.listType = .simple
+                    self.internalAndesList?.size = .medium
                     self.cellType = .chevron
                     self.thumbnailType = .icon
 
@@ -336,6 +332,7 @@ class AndesListTests: QuickSpec {
                 it("Check selection Style blue color") {
                     //Given
                     self.internalAndesList?.listType = .simple
+                    self.internalAndesList?.size = .large
                     self.cellType = .chevron
                     self.thumbnailType = .icon
 
@@ -349,6 +346,7 @@ class AndesListTests: QuickSpec {
                 it("Check selection Style default color") {
                     //Given
                     self.internalAndesList?.listType = .simple
+                    self.internalAndesList?.size = .small
                     self.cellType = .chevron
                     self.thumbnailType = .icon
 
@@ -362,6 +360,7 @@ class AndesListTests: QuickSpec {
                 it("Check selection Style none color") {
                     //Given
                     self.internalAndesList?.listType = .simple
+                    self.internalAndesList?.size = .medium
                     self.cellType = .chevron
                     self.thumbnailType = .icon
 
@@ -394,16 +393,16 @@ extension AndesListTests: AndesListDataSource {
         switch cellType {
         case .simple:
             let cell = AndesSimpleCell(withTitle: titleArray?[indexPath.row] ?? "",
-                                       size: .medium,
                                        subtitle: "Descripción -- Descripción -- Descripción -- Descripción")
+            cell.updateSize(size: self.size ?? .medium)
             return cell
         case .chevron:
             let thumbnail = AndesThumbnail(hierarchy: .defaultHierarchy, type: self.thumbnailType!, size: .size24, state: .enabled, image: UIImage(named: "andes") ?? UIImage(), accentColor: UIColor.clear)
 
             let cell = AndesChevronCell(withTitle: titleArray?[indexPath.row] ?? "",
-                                        size: .medium,
                                         subtitle: "Descripción de la celda",
                                         thumbnail: thumbnail)
+            cell.updateSize(size: self.size ?? .medium)
             return cell
         default:
             return AndesListCell()

--- a/LibraryComponents/Classes/Core/AndesList/AndesChevronCell.swift
+++ b/LibraryComponents/Classes/Core/AndesList/AndesChevronCell.swift
@@ -16,7 +16,6 @@ public class AndesChevronCell: AndesListCell {
      This method initialize an AndesChevronCell to draw the row just objc
      - Parameters:
        - title: Set the title for the cell
-       - size: Set the size for the cell, the values are small, medium and large, the default is medium
        - subtitle: Set the subtitle for the cell
        - thumbnail: Set a thumbnail to the left of the cell
        - numberOfLines: Set the number of lines to the cell title, the default is 0
@@ -25,19 +24,17 @@ public class AndesChevronCell: AndesListCell {
     */
     @available(swift, obsoleted: 1.0)
     @objc public init(withTitle title: String,
-                      size: AndesListSize,
                       subtitle: String,
                       thumbnail: AndesThumbnail? = nil,
                       numberOfLines: Int) {
         super.init()
-        self.cellConfig(withTitle: title, size: size, subtitle: subtitle, thumbnail: thumbnail, numberOfLines: numberOfLines)
+        self.cellConfig(withTitle: title, subtitle: subtitle, thumbnail: thumbnail, numberOfLines: numberOfLines)
     }
 
     /**
      This method initialize an AndesChevronCell to draw the row
      - Parameters:
        - title: Set the title for the cell
-       - size: Set the size for the cell, the values are small, medium and large, the default is medium
        - subtitle: Set the subtitle for the cell
        - thumbnail: Set a thumbnail to the left of the cell
        - numberOfLines: Set the number of lines to the cell title, the default is 0
@@ -45,25 +42,29 @@ public class AndesChevronCell: AndesListCell {
      - Version : Available since 3.13.0
     */
     public init(withTitle title: String,
-                size: AndesListSize? = .medium,
                 subtitle: String? = String(),
-                thumbnail: AndesThumbnail? = nil, numberOfLines: Int = 0) {
+                thumbnail: AndesThumbnail? = nil,
+                numberOfLines: Int = 0) {
         super.init()
-        guard let size = size, let subtitle = subtitle else { return }
-        self.cellConfig(withTitle: title, size: size, subtitle: subtitle, thumbnail: thumbnail, numberOfLines: numberOfLines)
+        self.cellConfig(withTitle: title, subtitle: subtitle, thumbnail: thumbnail, numberOfLines: numberOfLines)
     }
 
     private func cellConfig(withTitle title: String,
-                            size: AndesListSize,
-                            subtitle: String,
+                            subtitle: String?,
                             thumbnail: AndesThumbnail? = nil,
                             numberOfLines: Int) {
+        self.type = .chevron
+        self.title = title
+        self.subtitle = subtitle ?? ""
+        self.numberOfLines = numberOfLines
+        self.thumbnail = thumbnail
+    }
+
+    override func updateSize(size: AndesListSize) {
         let config = AndesListCellFactory.provide(withSize: size,
                                                       subTitleIsEmpty: subtitle.isEmpty,
                                                       thumbnail: thumbnail)
-        self.type = .chevron
-        self.title = title
-        self.subtitle = subtitle
+
         self.fontStyle = config.font
         self.fontSubTitleStyle = config.fontDescription
         self.paddingLeftCell = config.paddingLeft
@@ -84,8 +85,7 @@ public class AndesChevronCell: AndesListCell {
         self.paddingTopChevron = config.paddingTopChevron
         self.paddingBottomChevron = config.paddingBottomChevron
         self.separatorChevronWidth = config.separatorChevronWidth
-        self.numberOfLines = numberOfLines
-        self.thumbnailType = thumbnail?.type
+
     }
 
     required init?(coder: NSCoder) {

--- a/LibraryComponents/Classes/Core/AndesList/AndesList.swift
+++ b/LibraryComponents/Classes/Core/AndesList/AndesList.swift
@@ -27,6 +27,9 @@ import Foundation
     /// Set the list type, default value simple
     @objc public var listType: AndesCellType = .simple
 
+    /// Set the list size, default value medium
+    @objc public var size: AndesListSize = .medium
+
     /// This method reload the data
     @objc public func reloadData() {
         self.tableView.reloadData()
@@ -96,6 +99,7 @@ extension AndesList: AndesListProtocol {
               customCell.type == listType else {
             fatalError("Cell type not allowed, should be \(listType.toString()) type")
         }
+        customCell.updateSize(size: self.size)
         return customCell
     }
 

--- a/LibraryComponents/Classes/Core/AndesList/AndesListCell.swift
+++ b/LibraryComponents/Classes/Core/AndesList/AndesListCell.swift
@@ -62,7 +62,7 @@ import UIKit
     var paddingTopChevron: CGFloat? = 0
     var paddingBottomChevron: CGFloat? = 0
     var numberOfLines: Int = 0
-    var thumbnailType: AndesThumbnailType?
+    var thumbnail: AndesThumbnail?
 
     required init?(coder: NSCoder) {
         super.init(coder: coder)
@@ -76,7 +76,7 @@ import UIKit
         self.setupUIComponents(customCell: customCell)
         self.setupSeparatorStyle(separatorStyle: separatorStyle)
         self.setupThumbnail(customCell: customCell)
-        self.setupAccessibilityProperties(thumbnailType: customCell.thumbnailType)
+        self.setupAccessibilityProperties(thumbnailType: customCell.thumbnail?.type)
     }
 
     func setupUIComponents(customCell: AndesListCell) {
@@ -108,7 +108,7 @@ import UIKit
 
     func setupThumbnail(customCell: AndesListCell) {
         if let imageSize = customCell.thumbnailSize, imageSize != 0.0 {
-            if customCell.thumbnailType == .icon {
+            if customCell.thumbnail?.type == .icon {
                 self.iconImgWidthConstraint.constant = imageSize
                 self.iconImgHeightConstraint.constant = imageSize
                 self.thumbnailWidthConstraint.constant = imageSize
@@ -122,7 +122,7 @@ import UIKit
                 self.iconImgWidthConstraint.constant = imageSize
                 self.iconImgHeightConstraint.constant = imageSize
                 self.thumbnailImg.image = customCell.thumbnailLeft
-                self.thumbnailImg.type = customCell.thumbnailType ?? .imageCircle
+                self.thumbnailImg.type = customCell.thumbnail?.type ?? .imageCircle
                 self.thumbnailImg.size = AndesThumbnailSize.floatToAndesThumbnailSize(value: customCell.thumbnailSize ?? 0)
                 self.thumbnailImg.isHidden = false
                 self.iconView.isHidden = true
@@ -158,5 +158,9 @@ import UIKit
             guard let type = thumbnailType else { return }
             thumbnailImg.accessibilityLabel = type == .icon ? "icon accessibility".localized() : "image accessibility".localized()
         }
+    }
+
+    func updateSize(size: AndesListSize) {
+        fatalError("This should be overriden by a subclass")
     }
 }

--- a/LibraryComponents/Classes/Core/AndesList/AndesSimpleCell.swift
+++ b/LibraryComponents/Classes/Core/AndesList/AndesSimpleCell.swift
@@ -16,7 +16,6 @@ public class AndesSimpleCell: AndesListCell {
      This method initialize an AndesSimpleCell to draw the row just objc
      - Parameters:
        - title: Set the title for the cell
-       - size: Set the size for the cell, the values are small, medium and large, the default is medium
        - subtitle: Set the subtitle for the cell
        - thumbnail: Set a thumbnail to the left of the cell
        - numberOfLines: Set the number of lines to the cell title, the default is 0
@@ -25,13 +24,11 @@ public class AndesSimpleCell: AndesListCell {
     */
     @available(swift, obsoleted: 1.0)
     @objc public init(withTitle title: String,
-                      size: AndesListSize,
                       subtitle: String,
                       thumbnail: AndesThumbnail? = nil,
                       numberOfLines: Int) {
         super.init()
         self.cellConfig(withTitle: title,
-                        size: size,
                         subtitle: subtitle,
                         thumbnail: thumbnail,
                         numberOfLines: numberOfLines)
@@ -41,7 +38,6 @@ public class AndesSimpleCell: AndesListCell {
      This method initialize an AndesSimpleCell to draw the row
      - Parameters:
        - title: Set the title for the cell
-       - size: Set the size for the cell, the values are small, medium and large, the default is medium, optional parameter
        - subtitle: Set the subtitle for the cell, optional parameter
        - thumbnail: Set a thumbnail to the left of the cell, optional parameter
        - numberOfLines: Set the number of lines to the cell title, the default is 0, optional parameter
@@ -49,30 +45,31 @@ public class AndesSimpleCell: AndesListCell {
      - Version : Available since 3.13.0
     */
     public init(withTitle title: String,
-                size: AndesListSize? = .medium,
                 subtitle: String? = String(),
                 thumbnail: AndesThumbnail? = nil,
                 numberOfLines: Int = 0) {
         super.init()
-        guard let size = size, let subtitle = subtitle else { return }
         self.cellConfig(withTitle: title,
-                        size: size,
                         subtitle: subtitle,
                         thumbnail: thumbnail,
                         numberOfLines: numberOfLines)
     }
 
     private func cellConfig(withTitle title: String,
-                            size: AndesListSize,
-                            subtitle: String,
+                            subtitle: String?,
                             thumbnail: AndesThumbnail? = nil,
                             numberOfLines: Int) {
-        let config = AndesListCellFactory.provide(withSize: size,
-                                                      subTitleIsEmpty: subtitle.isEmpty,
-                                                      thumbnail: thumbnail)
         self.type = .simple
         self.title = title
-        self.subtitle = subtitle
+        self.subtitle = subtitle ?? ""
+        self.numberOfLines = numberOfLines
+        self.thumbnail = thumbnail
+    }
+
+    override func updateSize(size: AndesListSize) {
+        let config = AndesListCellFactory.provide(withSize: size,
+                                                      subTitleIsEmpty: self.subtitle.isEmpty,
+                                                      thumbnail: self.thumbnail)
         self.fontStyle = config.font
         self.fontSubTitleStyle = config.fontDescription
         self.paddingLeftCell = config.paddingLeft
@@ -88,11 +85,9 @@ public class AndesSimpleCell: AndesListCell {
         self.separatorThumbnailWidth = config.separatorThumbnailWidth
         self.paddingTopThumbnail = config.paddingTopThumbnail
         self.paddingBottomThumbnail = config.paddingBottomThumbnail
-        self.numberOfLines = numberOfLines
-        self.thumbnailType = thumbnail?.type
     }
 
     required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
+        super.init(coder: coder)
     }
 }


### PR DESCRIPTION
### Thanks for contributing to Andes UI!
## Description
Se ajustó para que el tamaño de la fila sea definido desde la lista y no por cada fila, con esto conservamos el mismo tamaño por fila y no que permita tener diferentes tamaños por fila
## Affected component
AndesList
## RFC Link

## Screenshots / GIFs
<img width="584" alt="Captura de Pantalla 2020-11-26 a la(s) 7 58 30 a  m" src="https://user-images.githubusercontent.com/69221534/100353892-3c2f7680-2fbd-11eb-8bc2-40913757ae28.png">

## Checks
Are you sure you followed all those steps? If so, repeat after me "I solemnly swear that ...":
   - [x] I have coded an example inside the Demo App,
   - [x] I have added proper tests,
   - [x] I have modified the Changelog.md file,
   - [x] I have updated GitHub wiki,
   - [ ] I have the explicit approval of one or more members of the UX Team,
   - [x] I have checked that this code is ObjC compliant.
   - [ ] I have checked that all the new public enums conform to AndesEnumStringConvertible.
## Change type
This is easy, let us know what this code is about:
   - [ ] This code adds a new component
   - [x] This code includes improvements to an existent component
   - [ ] This code improves or modifies ONLY the Demo App.
