### PR TITLE
Fix icon components interaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unpublished
+### 🛠 Bug fixes
+- AndestextField: Fix icon component right and left interaction | Authors: [@joalonsopint](https://github.com/joalonsopint)
+
 # v3.16.0
 ### 🚀 Features
 - AndesCard: New property to make the padding independent in the body | Authors: [@federiconosmor](https://github.com/federiconosmor)

--- a/LibraryComponents/Classes/Core/AndesTextField/SideComponents/views/AndesTextFieldIconView.swift
+++ b/LibraryComponents/Classes/Core/AndesTextField/SideComponents/views/AndesTextFieldIconView.swift
@@ -37,5 +37,6 @@ class AndesTextFieldIconView: UIView {
         imageView.heightAnchor.constraint(equalToConstant: 20).isActive = true
         self.addSubview(imageView)
         imageView.pinToSuperview(top: 0, left: 12, bottom: 0, right: 12)
+        self.isUserInteractionEnabled = false
     }
 }

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,13 +1,13 @@
 PODS:
-  - AndesUI (3.14.0):
-    - AndesUI/Core (= 3.14.0)
-  - AndesUI/AndesBottomSheet (3.14.0):
+  - AndesUI (3.16.0):
+    - AndesUI/Core (= 3.16.0)
+  - AndesUI/AndesBottomSheet (3.16.0):
     - AndesUI/Core
-  - AndesUI/AndesCoachmark (3.14.0):
+  - AndesUI/AndesCoachmark (3.16.0):
     - AndesUI/Core
-  - AndesUI/Core (3.14.0):
+  - AndesUI/Core (3.16.0):
     - AndesUI/LocalIcons
-  - AndesUI/LocalIcons (3.14.0)
+  - AndesUI/LocalIcons (3.16.0)
   - IQKeyboardManagerSwift (6.3.0)
   - Nimble (7.3.4)
   - Quick (1.2.0)
@@ -31,7 +31,7 @@ EXTERNAL SOURCES:
     :path: "./"
 
 SPEC CHECKSUMS:
-  AndesUI: 548ad3f6707a25294da0e0a7ec7d3e69308e6d2d
+  AndesUI: 01b327d55fd0121217e36e70d8f5423fa4856430
   IQKeyboardManagerSwift: a8228c257614af98743b4cd8584637025f36358f
   Nimble: 051e3d8912d40138fa5591c78594f95fb172af37
   Quick: 58d203b1c5e27fff7229c4c1ae445ad7069a7a08


### PR DESCRIPTION
### Thanks for contributing to Andes UI!
## Description
Se desactiva la interacción de los componentes (Iconos) de la izquierda y derecha para AndesTextfield, lo que permite que al tocarlos se mantenga la acción del Texfield y realice el foco.
## Affected component
AndesTextField
## RFC Link

## Screenshots / GIFs
<img width="584" alt="image" src="https://user-images.githubusercontent.com/69221534/101665777-6a7c6f80-3a1b-11eb-9892-7ae520e32741.png">

## Checks
Are you sure you followed all those steps? If so, repeat after me "I solemnly swear that ...":
   - [ ] I have coded an example inside the Demo App,
   - [ ] I have added proper tests,
   - [x] I have modified the Changelog.md file,
   - [ ] I have updated GitHub wiki,
   - [ ] I have the explicit approval of one or more members of the UX Team,
   - [ ] I have checked that this code is ObjC compliant.
   - [ ] I have checked that all the new public enums conform to AndesEnumStringConvertible.
## Change type
This is easy, let us know what this code is about:
   - [ ] This code adds a new component
   - [x] This code includes improvements to an existent component
   - [ ] This code improves or modifies ONLY the Demo App.
