### PR TITLE
Feature/fix title bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### 🛠 Bug fixes
 - AndestextField: Fix icon component right and left interaction | Authors: [@joalonsopint](https://github.com/joalonsopint)
+- AndesBottomSheet: Fix title number of lines | Authors: [@joalonsopint](https://github.com/joalonsopint)
 
 # v3.16.0
 ### 🚀 Features

--- a/LibraryComponents/Classes/AndesBottomSheet/AndesBottomSheetViewController.swift
+++ b/LibraryComponents/Classes/AndesBottomSheet/AndesBottomSheetViewController.swift
@@ -19,7 +19,7 @@ private enum Constants {
             return UIApplication.shared.statusBarFrame.height
         }
     }
-    static let sizes: [AndesBottomSheetSize] = [.min(.intrinsic, .percent(0.80)),
+    static let sizes: [AndesBottomSheetSize] = [.min(.intrinsic, .percent(0.60)),
                                                 .min(.intrinsic, .fixedFromTop(Constants.marginFromTop))]
 }
 

--- a/LibraryComponents/Classes/AndesBottomSheet/AndesBottomSheetViewController.swift
+++ b/LibraryComponents/Classes/AndesBottomSheet/AndesBottomSheetViewController.swift
@@ -19,7 +19,7 @@ private enum Constants {
             return UIApplication.shared.statusBarFrame.height
         }
     }
-    static let sizes: [AndesBottomSheetSize] = [.min(.intrinsic, .percent(0.60)),
+    static let sizes: [AndesBottomSheetSize] = [.min(.intrinsic, .percent(0.80)),
                                                 .min(.intrinsic, .fixedFromTop(Constants.marginFromTop))]
 }
 

--- a/LibraryComponents/Classes/AndesBottomSheet/View/AndesBottomSheetTitleBar.swift
+++ b/LibraryComponents/Classes/AndesBottomSheet/View/AndesBottomSheetTitleBar.swift
@@ -37,16 +37,6 @@ public class AndesBottomSheetTitleBar: UIView {
         }
     }
 
-    @objc
-        public var numberOfLines: Int {
-            get {
-                return textLabel.numberOfLines
-            }
-            set {
-                textLabel.numberOfLines = newValue
-            }
-        }
-
     private let textLabel: UILabel = {
         let textLabel = UILabel()
         textLabel.font = AndesStyleSheetManager.styleSheet.semiboldSystemFontOfSize(size: AndesFontSize.titleS)

--- a/LibraryComponents/Classes/AndesBottomSheet/View/AndesBottomSheetTitleBar.swift
+++ b/LibraryComponents/Classes/AndesBottomSheet/View/AndesBottomSheetTitleBar.swift
@@ -51,7 +51,7 @@ public class AndesBottomSheetTitleBar: UIView {
         let textLabel = UILabel()
         textLabel.font = AndesStyleSheetManager.styleSheet.semiboldSystemFontOfSize(size: AndesFontSize.titleS)
         textLabel.textColor = UIColor.Andes.gray800
-        textLabel.numberOfLines = 1
+        textLabel.numberOfLines = 2
         return textLabel
     }()
 

--- a/LibraryComponents/Classes/AndesBottomSheet/View/AndesBottomSheetTitleBar.swift
+++ b/LibraryComponents/Classes/AndesBottomSheet/View/AndesBottomSheetTitleBar.swift
@@ -37,6 +37,16 @@ public class AndesBottomSheetTitleBar: UIView {
         }
     }
 
+    @objc
+        public var numberOfLines: Int {
+            get {
+                return textLabel.numberOfLines
+            }
+            set {
+                textLabel.numberOfLines = newValue
+            }
+        }
+
     private let textLabel: UILabel = {
         let textLabel = UILabel()
         textLabel.font = AndesStyleSheetManager.styleSheet.semiboldSystemFontOfSize(size: AndesFontSize.titleS)

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,13 +1,13 @@
 PODS:
-  - AndesUI (3.14.0):
-    - AndesUI/Core (= 3.14.0)
-  - AndesUI/AndesBottomSheet (3.14.0):
+  - AndesUI (3.14.1):
+    - AndesUI/Core (= 3.14.1)
+  - AndesUI/AndesBottomSheet (3.14.1):
     - AndesUI/Core
-  - AndesUI/AndesCoachmark (3.14.0):
+  - AndesUI/AndesCoachmark (3.14.1):
     - AndesUI/Core
-  - AndesUI/Core (3.14.0):
+  - AndesUI/Core (3.14.1):
     - AndesUI/LocalIcons
-  - AndesUI/LocalIcons (3.14.0)
+  - AndesUI/LocalIcons (3.14.1)
   - IQKeyboardManagerSwift (6.3.0)
   - Nimble (7.3.4)
   - Quick (1.2.0)
@@ -31,7 +31,7 @@ EXTERNAL SOURCES:
     :path: "./"
 
 SPEC CHECKSUMS:
-  AndesUI: 548ad3f6707a25294da0e0a7ec7d3e69308e6d2d
+  AndesUI: f541cc77b02d05eabe75ef84c654f886b302b4c8
   IQKeyboardManagerSwift: a8228c257614af98743b4cd8584637025f36358f
   Nimble: 051e3d8912d40138fa5591c78594f95fb172af37
   Quick: 58d203b1c5e27fff7229c4c1ae445ad7069a7a08


### PR DESCRIPTION
### Thanks for contributing to Andes UI!
## Description
Permitirá tener dos líneas para el título del bottom sheet
## Affected component
AndesBottomSheet
## RFC Link

## Screenshots / GIFs
<img width="584" alt="image" src="https://user-images.githubusercontent.com/69221534/101687760-f6e95b00-3a38-11eb-82ce-ed6f5fea5927.png">

## Checks
Are you sure you followed all those steps? If so, repeat after me "I solemnly swear that ...":
   - [ ] I have coded an example inside the Demo App,
   - [ ] I have added proper tests,
   - [x] I have modified the Changelog.md file,
   - [ ] I have updated GitHub wiki,
   - [ ] I have the explicit approval of one or more members of the UX Team,
   - [ ] I have checked that this code is ObjC compliant.
   - [ ] I have checked that all the new public enums conform to AndesEnumStringConvertible.
## Change type
This is easy, let us know what this code is about:
   - [ ] This code adds a new component
   - [x] This code includes improvements to an existent component
   - [ ] This code improves or modifies ONLY the Demo App.
