### PR TITLE
 Tag View Choice animation parameter fixed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ### 🚀 Features
 - AndesProgressIndicatorIndeterminate: support new size in AndesProgressIndicator | Authors: [@javff](https://github.com/javff)
 - AndesDropdown  component  | Authors: [@joalonsopint](https://github.com/joalonsopint)
+-AndesTagChoice component fix animation parameter | Authors: [@frank8MELI](https://github.com/frank8MELI)
 
 # v3.17.0
 ### 🚀 Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 ### 🚀 Features
 - AndesProgressIndicatorIndeterminate: support new size in AndesProgressIndicator | Authors: [@javff](https://github.com/javff)
 - AndesDropdown  component  | Authors: [@joalonsopint](https://github.com/joalonsopint)
--AndesTagChoice component fix animation parameter | Authors: [@frank8MELI](https://github.com/frank8MELI)
+
+### 🛠 Bug fixes
+- [Breaking] AndesTagChoice component fix animation parameter | Authors: [@frank8MELI](https://github.com/frank8MELI)
 
 # v3.17.0
 ### 🚀 Features

--- a/LibraryComponents/Classes/Core/AndesTag/AndesTagChoice.swift
+++ b/LibraryComponents/Classes/Core/AndesTag/AndesTagChoice.swift
@@ -46,8 +46,8 @@ import Foundation
         }
     }
 
-    /// Set if the view has to animate when tag was selected. Default value `true`
-    @objc public var shouldAnimateTag: Bool = true
+    /// Set if the view has to animate when tag was selected. Default value `false`
+    @objc public var shouldAnimateTag: Bool = false
 
     /// Callback invoked when tag is tapped
     internal var shouldSelectTag: (() -> Bool)?

--- a/LibraryComponents/Classes/Core/AndesTag/View/AndesTagChoiceView.swift
+++ b/LibraryComponents/Classes/Core/AndesTag/View/AndesTagChoiceView.swift
@@ -16,10 +16,12 @@ class AndesTagChoiceView: AndesTagSimpleView {
         self.accessibilityLabel = config.accessibilityLabel
     }
     override func setupRightContent() {
-            super.setupRightContent()
-            if config.shouldAnimateRightContent {
-               self.layoutIfNeeded()
+        super.setupRightContent()
+        if config.shouldAnimateRightContent {
+            UIView.animate(withDuration: 0.3) {
+                self.layoutIfNeeded()
             }
         }
+    }
 
 }

--- a/LibraryComponents/Classes/Core/AndesTag/View/AndesTagChoiceView.swift
+++ b/LibraryComponents/Classes/Core/AndesTag/View/AndesTagChoiceView.swift
@@ -15,5 +15,11 @@ class AndesTagChoiceView: AndesTagSimpleView {
         self.isAccessibilityElement = true
         self.accessibilityLabel = config.accessibilityLabel
     }
+    override func setupRightContent() {
+            super.setupRightContent()
+            if config.shouldAnimateRightContent {
+               self.layoutIfNeeded()
+            }
+        }
 
 }

--- a/LibraryComponents/Classes/Core/AndesTag/View/AndesTagChoiceView.swift
+++ b/LibraryComponents/Classes/Core/AndesTag/View/AndesTagChoiceView.swift
@@ -16,12 +16,4 @@ class AndesTagChoiceView: AndesTagSimpleView {
         self.accessibilityLabel = config.accessibilityLabel
     }
 
-    override func setupRightContent() {
-        super.setupRightContent()
-        if config.shouldAnimateRightContent {
-            UIView.animate(withDuration: 0.3) {
-                self.layoutIfNeeded()
-            }
-        }
-    }
 }


### PR DESCRIPTION
### Thanks for contributing to Andes UI!
## Description
Se corrige el parámetro shouldAnimateTag inicializado por defecto como true que provocaba una extraña animación en la barra de filtros de la librería UIComponents
## Affected component
AndesTagChoice
## Screenshots / GIFs
<table>
<tr>
    <th>Before</th>
    <th>After</th>
</tr>
<tr>
    <td><img src="https://user-images.githubusercontent.com/60758034/102394346-6242a800-3fb8-11eb-8eb5-fe6bb7ff2dc8.gif"  width=300></img> </td>
 <td><img src="https://user-images.githubusercontent.com/60758034/102394372-6b337980-3fb8-11eb-9c62-53d7c0d8aec9.gif" width=300></img></td>
</tr>
</table>

## Checks
Are you sure you followed all those steps? If so, repeat after me "I solemnly swear that ...":
   - [ ] I have coded an example inside the Demo App,
   - [ ] I have added proper tests,
   - [x] I have modified the Changelog.md file,
   - [ ] I have updated GitHub wiki,
   - [ ] I have the explicit approval of one or more members of the UX Team,
   - [ ] I have checked that this code is ObjC compliant.
   - [ ] I have checked that all the new public enums conform to AndesEnumStringConvertible.
## Change type
This is easy, let us know what this code is about:
   - [ ] This code adds a new component
   - [x] This code includes improvements to an existent component
   - [ ] This code improves or modifies ONLY the Demo App.
