### PR TITLE
Adding property to set the number of lines the radiobutton

### DIFF
--- a/Example/AndesUI/RadioButton/Views/AndesRadioButtonViewController.swift
+++ b/Example/AndesUI/RadioButton/Views/AndesRadioButtonViewController.swift
@@ -19,6 +19,7 @@ class AndesRadioButtonViewController: UIViewController, RadioButtonView {
     @IBOutlet weak var statusTxt: UITextField!
     @IBOutlet weak var alignTxt: UITextField!
     @IBOutlet weak var radioButtonTxt: UITextField!
+    @IBOutlet weak var numberLinesTxt: UITextField!
 
     @IBOutlet weak var updateBtn: UIButton!
     @IBOutlet weak var clearBtn: UIButton!
@@ -37,6 +38,11 @@ class AndesRadioButtonViewController: UIViewController, RadioButtonView {
 
     @IBAction func updateTapped(_ sender: Any) {
         self.radioButton.title = radioButtonTxt.text
+        self.radioButton.titleNumberOfLines = 0
+
+        if let text = numberLinesTxt.text, let numberLines = Int(text) {
+            self.radioButton.titleNumberOfLines = numberLines
+        }
     }
 
     @IBAction func clearTapped(_ sender: Any) {
@@ -48,6 +54,7 @@ class AndesRadioButtonViewController: UIViewController, RadioButtonView {
         typeText.text = self.radioButton.type.toString()
         statusTxt.text = self.radioButton.status.toString()
         alignTxt.text = self.radioButton.align.toString()
+        numberLinesTxt.text = "0"
 
         radioButtonTxt.text = ""
     }

--- a/Example/AndesUI/RadioButton/Views/AndesRadioButtonViewController.xib
+++ b/Example/AndesUI/RadioButton/Views/AndesRadioButtonViewController.xib
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15705" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15706"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17126"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -12,6 +13,7 @@
             <connections>
                 <outlet property="alignTxt" destination="LCw-QB-Mfv" id="ptX-m3-Wwg"/>
                 <outlet property="clearBtn" destination="jAR-mm-eeW" id="HiL-mP-l2v"/>
+                <outlet property="numberLinesTxt" destination="wIw-6s-vyh" id="INt-VL-AwJ"/>
                 <outlet property="radioButton" destination="zhE-sd-tpD" id="DpP-qY-LKm"/>
                 <outlet property="radioButtonTxt" destination="RnL-ig-JUl" id="5GZ-Qc-QyS"/>
                 <outlet property="statusTxt" destination="hYw-3i-glO" id="TD0-Zy-Pir"/>
@@ -26,7 +28,7 @@
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="4bW-nu-PyM">
-                    <rect key="frame" x="50" y="119" width="314" height="442"/>
+                    <rect key="frame" x="50" y="74" width="314" height="476"/>
                     <subviews>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Type" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Rkj-iL-29z">
                             <rect key="frame" x="0.0" y="143" width="37.5" height="21"/>
@@ -35,7 +37,7 @@
                             <nil key="highlightedColor"/>
                         </label>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Status" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="67m-Gz-5nL">
-                            <rect key="frame" x="0.0" y="184" width="49.5" height="21"/>
+                            <rect key="frame" x="0.0" y="184" width="49" height="21"/>
                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                             <nil key="textColor"/>
                             <nil key="highlightedColor"/>
@@ -70,28 +72,23 @@
                             <fontDescription key="fontDescription" type="system" pointSize="14"/>
                             <textInputTraits key="textInputTraits"/>
                         </textField>
-                        <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Checkbox text" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="RnL-ig-JUl" userLabel="radiobutton text">
-                            <rect key="frame" x="8" y="273" width="298" height="34"/>
-                            <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                            <textInputTraits key="textInputTraits"/>
-                        </textField>
-                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="QmN-5v-7sp">
-                            <rect key="frame" x="8" y="327" width="51" height="30"/>
+                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="QmN-5v-7sp">
+                            <rect key="frame" x="8" y="361" width="51" height="30"/>
                             <state key="normal" title="Update"/>
                             <connections>
                                 <action selector="updateTapped:" destination="-1" eventType="touchUpInside" id="doT-su-8nS"/>
                             </connections>
                         </button>
-                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="jAR-mm-eeW">
-                            <rect key="frame" x="270" y="327" width="36" height="30"/>
+                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="jAR-mm-eeW">
+                            <rect key="frame" x="270" y="361" width="36" height="30"/>
                             <state key="normal" title="Clear"/>
                             <connections>
                                 <action selector="clearTapped:" destination="-1" eventType="touchUpInside" id="rJX-3F-wfW"/>
                             </connections>
                         </button>
                         <view contentMode="scaleToFill" placeholderIntrinsicWidth="240" placeholderIntrinsicHeight="45" translatesAutoresizingMaskIntoConstraints="NO" id="zhE-sd-tpD" customClass="AndesRadioButton" customModule="AndesUI">
-                            <rect key="frame" x="37" y="50" width="240" height="45"/>
-                            <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                            <rect key="frame" x="0.0" y="30" width="314" height="45"/>
+                            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                             <userDefinedRuntimeAttributes>
                                 <userDefinedRuntimeAttribute type="string" keyPath="title" value="Radio Button"/>
                                 <userDefinedRuntimeAttribute type="string" keyPath="ibType" value="idle"/>
@@ -99,29 +96,55 @@
                                 <userDefinedRuntimeAttribute type="string" keyPath="ibAlign" value="left"/>
                             </userDefinedRuntimeAttributes>
                         </view>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Number of Lines" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="kRM-oh-Ikv">
+                            <rect key="frame" x="0.0" y="266" width="126" height="21"/>
+                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                            <nil key="textColor"/>
+                            <nil key="highlightedColor"/>
+                        </label>
+                        <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="0" borderStyle="roundedRect" placeholder="number of lines" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="wIw-6s-vyh">
+                            <rect key="frame" x="244" y="259.5" width="70" height="34"/>
+                            <constraints>
+                                <constraint firstAttribute="width" constant="70" id="R6s-AW-j9z"/>
+                            </constraints>
+                            <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                            <textInputTraits key="textInputTraits" keyboardType="numberPad"/>
+                        </textField>
+                        <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Checkbox text" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="RnL-ig-JUl" userLabel="radiobutton text">
+                            <rect key="frame" x="8" y="307" width="298" height="34"/>
+                            <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                            <textInputTraits key="textInputTraits"/>
+                        </textField>
                     </subviews>
                     <constraints>
                         <constraint firstItem="qgF-MF-lth" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="Rkj-iL-29z" secondAttribute="trailing" constant="10" id="0i5-6e-QKP"/>
                         <constraint firstAttribute="trailing" secondItem="hYw-3i-glO" secondAttribute="trailing" id="27O-71-JRg"/>
+                        <constraint firstItem="wIw-6s-vyh" firstAttribute="centerY" secondItem="kRM-oh-Ikv" secondAttribute="centerY" id="2OH-Jb-IFQ"/>
                         <constraint firstItem="8ga-Fs-LXn" firstAttribute="leading" secondItem="4bW-nu-PyM" secondAttribute="leading" id="3U3-aB-K48"/>
                         <constraint firstAttribute="trailing" secondItem="jAR-mm-eeW" secondAttribute="trailing" constant="8" id="8ab-lQ-LFr"/>
                         <constraint firstItem="Rkj-iL-29z" firstAttribute="leading" secondItem="4bW-nu-PyM" secondAttribute="leading" id="ATt-Yo-mQX"/>
                         <constraint firstItem="RnL-ig-JUl" firstAttribute="leading" secondItem="4bW-nu-PyM" secondAttribute="leading" constant="8" id="AUp-0n-CU1"/>
                         <constraint firstItem="67m-Gz-5nL" firstAttribute="leading" secondItem="4bW-nu-PyM" secondAttribute="leading" id="Bel-in-KSz"/>
-                        <constraint firstItem="zhE-sd-tpD" firstAttribute="top" secondItem="4bW-nu-PyM" secondAttribute="top" constant="50" id="Hv4-Ve-jOL"/>
+                        <constraint firstItem="zhE-sd-tpD" firstAttribute="top" secondItem="4bW-nu-PyM" secondAttribute="top" constant="30" id="Hv4-Ve-jOL"/>
                         <constraint firstItem="67m-Gz-5nL" firstAttribute="top" secondItem="Rkj-iL-29z" secondAttribute="bottom" constant="20" id="IfM-QN-mCX"/>
+                        <constraint firstItem="kRM-oh-Ikv" firstAttribute="top" secondItem="8ga-Fs-LXn" secondAttribute="bottom" constant="20" id="JZl-Sw-ba7"/>
                         <constraint firstAttribute="trailing" secondItem="RnL-ig-JUl" secondAttribute="trailing" constant="8" id="K9O-nf-HVU"/>
+                        <constraint firstAttribute="trailing" secondItem="zhE-sd-tpD" secondAttribute="trailing" id="KJO-FX-BcG"/>
                         <constraint firstAttribute="trailing" secondItem="qgF-MF-lth" secondAttribute="trailing" id="Nku-7P-AuS"/>
+                        <constraint firstItem="kRM-oh-Ikv" firstAttribute="leading" secondItem="4bW-nu-PyM" secondAttribute="leading" id="QCd-3s-847"/>
                         <constraint firstItem="QmN-5v-7sp" firstAttribute="top" secondItem="RnL-ig-JUl" secondAttribute="bottom" constant="20" id="QVn-WA-jFi"/>
+                        <constraint firstItem="RnL-ig-JUl" firstAttribute="top" secondItem="kRM-oh-Ikv" secondAttribute="bottom" constant="20" id="VBV-Lv-7ou"/>
                         <constraint firstItem="QmN-5v-7sp" firstAttribute="leading" secondItem="4bW-nu-PyM" secondAttribute="leading" constant="8" id="VoV-1B-OpJ"/>
-                        <constraint firstItem="RnL-ig-JUl" firstAttribute="top" secondItem="8ga-Fs-LXn" secondAttribute="bottom" constant="27" id="Zr6-Yp-NVU"/>
                         <constraint firstItem="zhE-sd-tpD" firstAttribute="centerX" secondItem="4bW-nu-PyM" secondAttribute="centerX" id="fNQ-hH-F3C"/>
                         <constraint firstItem="Rkj-iL-29z" firstAttribute="top" secondItem="4bW-nu-PyM" secondAttribute="top" constant="143" id="feD-Pq-LyO"/>
                         <constraint firstItem="jAR-mm-eeW" firstAttribute="top" secondItem="RnL-ig-JUl" secondAttribute="bottom" constant="20" id="fwj-51-VBf"/>
                         <constraint firstItem="qgF-MF-lth" firstAttribute="centerY" secondItem="Rkj-iL-29z" secondAttribute="centerY" id="hYV-Ol-Et1"/>
+                        <constraint firstAttribute="trailing" secondItem="wIw-6s-vyh" secondAttribute="trailing" id="ivC-kL-gWw"/>
                         <constraint firstItem="hYw-3i-glO" firstAttribute="centerY" secondItem="67m-Gz-5nL" secondAttribute="centerY" id="jSx-Ri-rfC"/>
                         <constraint firstItem="LCw-QB-Mfv" firstAttribute="centerY" secondItem="8ga-Fs-LXn" secondAttribute="centerY" id="jdc-Zw-AGa"/>
+                        <constraint firstItem="wIw-6s-vyh" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="kRM-oh-Ikv" secondAttribute="trailing" constant="10" id="m3a-kX-1JU"/>
                         <constraint firstItem="LCw-QB-Mfv" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="8ga-Fs-LXn" secondAttribute="trailing" constant="10" id="seb-Se-5eZ"/>
+                        <constraint firstItem="zhE-sd-tpD" firstAttribute="leading" secondItem="4bW-nu-PyM" secondAttribute="leading" id="v7S-3u-r8j"/>
                         <constraint firstAttribute="bottom" secondItem="QmN-5v-7sp" secondAttribute="bottom" constant="85" id="vLk-pf-SXn"/>
                         <constraint firstItem="hYw-3i-glO" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="67m-Gz-5nL" secondAttribute="trailing" constant="10" id="vp9-kJ-Pnh"/>
                         <constraint firstAttribute="trailing" secondItem="LCw-QB-Mfv" secondAttribute="trailing" id="wug-H8-z7Q"/>
@@ -129,15 +152,20 @@
                     </constraints>
                 </view>
             </subviews>
+            <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
             <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
             <constraints>
                 <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="4bW-nu-PyM" secondAttribute="trailing" constant="50" id="7D5-GE-Zqh"/>
                 <constraint firstItem="4bW-nu-PyM" firstAttribute="centerX" secondItem="iN0-l3-epB" secondAttribute="centerX" id="enP-8e-H8y"/>
                 <constraint firstItem="4bW-nu-PyM" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" constant="50" id="nss-dD-dc5"/>
-                <constraint firstItem="4bW-nu-PyM" firstAttribute="top" secondItem="vUN-kp-3ea" secondAttribute="top" constant="75" id="zUV-sx-jX5"/>
+                <constraint firstItem="4bW-nu-PyM" firstAttribute="top" secondItem="vUN-kp-3ea" secondAttribute="top" constant="30" id="zUV-sx-jX5"/>
             </constraints>
-            <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
             <point key="canvasLocation" x="137.68115942028987" y="93.75"/>
         </view>
     </objects>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
 </document>

--- a/LibraryComponents/Classes/Core/AndesRadioButton/AndesRadioButton.swift
+++ b/LibraryComponents/Classes/Core/AndesRadioButton/AndesRadioButton.swift
@@ -18,6 +18,13 @@ import UIKit
         }
     }
 
+    /// Sets the number of lines the title of the RadioButton
+    public var titleNumberOfLines: Int? {
+        didSet {
+            self.updateContentView()
+        }
+    }
+
     /// Sets the type of the RadioButton , default idle
     @objc public var type: AndesRadioButtonType = .idle {
         didSet {

--- a/LibraryComponents/Classes/Core/AndesRadioButton/Config/AndesRadioButtonConfig.swift
+++ b/LibraryComponents/Classes/Core/AndesRadioButton/Config/AndesRadioButtonConfig.swift
@@ -15,6 +15,7 @@ internal struct AndesRadioButtonConfig {
     var align: AndesRadioButtonAlign = AndesRadioButtonAlign.left
     var type: AndesRadioButtonTypeProtocol! = AndesRadioButtonTypeIdle()
     var filled: Bool = false
+    var titleNumberOfLines: Int?
 
     init () {
 
@@ -27,5 +28,6 @@ internal struct AndesRadioButtonConfig {
         self.textColor = type.textColor
         self.tintColor = type.tintColor
         self.filled = radiobutton.status == .selected && radiobutton.type != .error
+        self.titleNumberOfLines = radiobutton.titleNumberOfLines
     }
 }

--- a/LibraryComponents/Classes/Core/AndesRadioButton/View/AndesRadioButtonDefaultView.swift
+++ b/LibraryComponents/Classes/Core/AndesRadioButton/View/AndesRadioButtonDefaultView.swift
@@ -78,6 +78,7 @@ class AndesRadioButtonDefaultView: UIView, AndesRadioButtonView {
         self.radioButtonLabel.text = config.title
         self.radioButtonLabel.setAndesStyle(style: AndesStyleSheetManager.styleSheet.bodyM(color: config.textColor))
         self.radioButtonLabel.numberOfLines = config.titleNumberOfLines ?? 0
+        radioButtonLabel.lineBreakMode = .byTruncatingTail
         setupButtonView()
         updateRadioButtonsStyles()
         updateAccessibilityProperties()

--- a/LibraryComponents/Classes/Core/AndesRadioButton/View/AndesRadioButtonDefaultView.swift
+++ b/LibraryComponents/Classes/Core/AndesRadioButton/View/AndesRadioButtonDefaultView.swift
@@ -77,12 +77,15 @@ class AndesRadioButtonDefaultView: UIView, AndesRadioButtonView {
     func updateView() {
         self.radioButtonLabel.text = config.title
         self.radioButtonLabel.setAndesStyle(style: AndesStyleSheetManager.styleSheet.bodyM(color: config.textColor))
+        self.radioButtonLabel.numberOfLines = config.titleNumberOfLines ?? 0
         setupButtonView()
         updateRadioButtonsStyles()
         updateAccessibilityProperties()
     }
 
     func setupButtonView() {
+        var radiobuttonConstraint = NSLayoutConstraint()
+
         if config.align == .left {
             self.rightRadioButton.isHidden = true
             self.leftRadioButton.isHidden = false
@@ -91,6 +94,8 @@ class AndesRadioButtonDefaultView: UIView, AndesRadioButtonView {
             self.labelToLeftButtonConstraint.priority = .defaultHigh
             self.labelToLeadingConstraint.priority = .defaultLow
             self.leftRadioButton.filled = config.filled
+
+            radiobuttonConstraint = NSLayoutConstraint(item: self.radioButtonLabel!, attribute: .leading, relatedBy: .equal, toItem: self.leftRadioButton!, attribute: .trailing, multiplier: 1, constant: 0)
         } else {
             self.rightRadioButton.isHidden = false
             self.leftRadioButton.isHidden = true
@@ -99,7 +104,10 @@ class AndesRadioButtonDefaultView: UIView, AndesRadioButtonView {
             self.labelToLeftButtonConstraint.priority = .defaultLow
             self.labelToLeadingConstraint.priority = .defaultHigh
             self.rightRadioButton.filled = config.filled
+
+            radiobuttonConstraint = NSLayoutConstraint(item: self.rightRadioButton!, attribute: .leading, relatedBy: .equal, toItem: radioButtonLabel, attribute: .trailing, multiplier: 1, constant: 0)
         }
+        NSLayoutConstraint.activate([radiobuttonConstraint])
     }
 
     func updateRadioButtonsStyles() {

--- a/LibraryComponents/Classes/Core/AndesRadioButton/View/AndesRadioButtonDefaultView.xib
+++ b/LibraryComponents/Classes/Core/AndesRadioButton/View/AndesRadioButtonDefaultView.xib
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15705" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15706"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17126"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -31,16 +32,17 @@
                     <nil key="highlightedColor"/>
                 </label>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="tMQ-xe-WWY" customClass="AndesRadioButtonControl" customModule="AndesUI">
-                    <rect key="frame" x="4" y="8" width="32" height="32"/>
-                    <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                    <rect key="frame" x="4" y="6" width="32" height="32"/>
+                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="32" id="DZq-eE-jax"/>
                         <constraint firstAttribute="height" constant="32" id="aj5-H1-qiM"/>
+                        <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="32" id="j3V-iJ-cCP"/>
                     </constraints>
                 </view>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="UBx-hG-Q69" customClass="AndesRadioButtonControl" customModule="AndesUI">
-                    <rect key="frame" x="144" y="8" width="32" height="32"/>
-                    <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                    <rect key="frame" x="144" y="6" width="32" height="32"/>
+                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="32" id="94b-Xg-F6T"/>
                         <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="32" id="C1K-vJ-jZ4"/>
@@ -55,14 +57,19 @@
                 <constraint firstItem="1Wf-Ci-oc3" firstAttribute="leading" secondItem="d18-F7-uIb" secondAttribute="leading" priority="250" constant="12" id="TeU-4P-92b"/>
                 <constraint firstItem="1Wf-Ci-oc3" firstAttribute="top" secondItem="d18-F7-uIb" secondAttribute="top" constant="12" id="aXd-WI-HlA"/>
                 <constraint firstAttribute="bottom" secondItem="1Wf-Ci-oc3" secondAttribute="bottom" constant="12" id="exm-ys-R35"/>
-                <constraint firstItem="UBx-hG-Q69" firstAttribute="centerY" secondItem="1Wf-Ci-oc3" secondAttribute="centerY" id="r3N-2i-xfx"/>
-                <constraint firstItem="tMQ-xe-WWY" firstAttribute="centerY" secondItem="1Wf-Ci-oc3" secondAttribute="centerY" id="saY-fX-DBu"/>
+                <constraint firstItem="1Wf-Ci-oc3" firstAttribute="top" secondItem="UBx-hG-Q69" secondAttribute="top" constant="6" id="r3N-2i-xfx"/>
+                <constraint firstItem="1Wf-Ci-oc3" firstAttribute="top" secondItem="tMQ-xe-WWY" secondAttribute="top" constant="6" id="saY-fX-DBu"/>
                 <constraint firstAttribute="trailing" secondItem="UBx-hG-Q69" secondAttribute="trailing" constant="4" id="uFe-6X-uGh"/>
                 <constraint firstAttribute="trailing" secondItem="1Wf-Ci-oc3" secondAttribute="trailing" priority="250" constant="12" id="uGC-e4-iLB"/>
-                <constraint firstItem="1Wf-Ci-oc3" firstAttribute="leading" secondItem="tMQ-xe-WWY" secondAttribute="trailing" priority="750" constant="4" id="uO2-4H-fYY"/>
+                <constraint firstItem="1Wf-Ci-oc3" firstAttribute="leading" secondItem="tMQ-xe-WWY" secondAttribute="trailing" constant="4" id="uO2-4H-fYY"/>
             </constraints>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
             <point key="canvasLocation" x="-36" y="-244"/>
         </view>
     </objects>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
 </document>

--- a/LibraryComponents/Classes/Core/AndesRadioButton/View/AndesRadioButtonDefaultView.xib
+++ b/LibraryComponents/Classes/Core/AndesRadioButton/View/AndesRadioButtonDefaultView.xib
@@ -64,7 +64,7 @@
                 <constraint firstItem="1Wf-Ci-oc3" firstAttribute="leading" secondItem="tMQ-xe-WWY" secondAttribute="trailing" constant="4" id="uO2-4H-fYY"/>
             </constraints>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
-            <point key="canvasLocation" x="-36" y="-244"/>
+            <point key="canvasLocation" x="-36.231884057971016" y="-244.41964285714283"/>
         </view>
     </objects>
     <resources>


### PR DESCRIPTION
### Thanks for contributing to Andes UI!

## Description
A public property is added to set the number of lines in the radio button

## Affected component
This code affects the andes radio buton lib.

## RFC Link
[RFC #101-89](https://docs.google.com/document/d/1A0eMaJVdyIHrAZNVLZl_phkad5KUUVtAU7Q75gZ3a5c)

## Screenshots / GIFs
![AndesRadioButton](https://user-images.githubusercontent.com/63119543/103219814-7d3ce280-48fd-11eb-87f8-d01c8af346c3.gif)

## Checks
Are you sure you followed all those steps? If so, repeat after me "I solemnly swear that ...":
   - [x] I have coded an example inside the Demo App,
   - [ ] I have added proper tests,
   - [ ] I have modified the Changelog.md file,
   - [ ] I have updated GitHub wiki,
   - [ ] I have the explicit approval of one or more members of the UX Team,
   - [ ] I have checked that this code is ObjC compliant.
   - [ ] I have checked that all the new public enums conform to AndesEnumStringConvertible.
  
## Change type
This is easy, let us know what this code is about:
   - [ ] This code adds a new component
   - [x] This code includes improvements to an existent component
   - [ ] This code improves or modifies ONLY the Demo App.
