### PR TITLE
Fix blocks xcode 11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - AndesProgressIndicatorIndeterminate: support new size in AndesProgressIndicator | Authors: [@javff](https://github.com/javff)
 - AndesDropdown  component  | Authors: [@joalonsopint](https://github.com/joalonsopint)
 - AndesButton: add spinner variant in AndesButton | Authors: [@javff](https://github.com/javff)
+- AndesButton: Fix trailing closure XCode 11 | Authors [joalonspint](https://github.com/joalonsopint)
 
 ### 🛠 Bug fixes
 - [Breaking] AndesTagChoice component fix animation parameter | Authors: [@frank8MELI](https://github.com/frank8MELI)

--- a/LibraryComponents/Classes/Core/AndesButton/View/AndesButtonAbstractView.swift
+++ b/LibraryComponents/Classes/Core/AndesButton/View/AndesButtonAbstractView.swift
@@ -194,13 +194,13 @@ extension AndesButtonAbstractView {
 
         UIView.animate(
             withDuration: spinnerTransitionDuration,
-            delay: 0,
-            options: [.curveEaseIn]) {
-            self.contentView.transform = CGAffineTransform(translationX: 0, y: -self.spinnerTransitionPosition)
-            self.spinner.transform = CGAffineTransform(translationX: 0, y: 0)
-            self.spinner.alpha = 1
-            self.contentView.alpha = 0
-        }
+            delay: 0, options: [.curveEaseIn],
+            animations: {
+                self.contentView.transform = CGAffineTransform(translationX: 0, y: -self.spinnerTransitionPosition)
+                self.spinner.transform = CGAffineTransform(translationX: 0, y: 0)
+                self.spinner.alpha = 1
+                self.contentView.alpha = 0
+        }) { (_) in }
     }
 
     private func dissapearSpinnerAnimation(completion: (() -> Void)? = nil) {
@@ -213,15 +213,12 @@ extension AndesButtonAbstractView {
         UIView.animate(
             withDuration: spinnerTransitionDuration,
             delay: 0,
-            options: [.curveEaseIn]) {
-            self.spinner.transform = CGAffineTransform(translationX: 0, y: -self.spinnerTransitionPosition)
-            self.contentView.transform = CGAffineTransform(translationX: 0, y: 0)
-            self.spinner.alpha = 0
-            self.contentView.alpha = 1
-        }
-
-        completion: { (_) in
-            completion?()
-        }
+            options: [.curveEaseIn],
+            animations: {
+                self.spinner.transform = CGAffineTransform(translationX: 0, y: -self.spinnerTransitionPosition)
+                self.contentView.transform = CGAffineTransform(translationX: 0, y: 0)
+                self.spinner.alpha = 0
+                self.contentView.alpha = 1
+        }) { (_) in }
     }
 }

--- a/LibraryComponents/Classes/Core/AndesButton/View/AndesButtonAbstractView.swift
+++ b/LibraryComponents/Classes/Core/AndesButton/View/AndesButtonAbstractView.swift
@@ -200,7 +200,7 @@ extension AndesButtonAbstractView {
                 self.spinner.transform = CGAffineTransform(translationX: 0, y: 0)
                 self.spinner.alpha = 1
                 self.contentView.alpha = 0
-        }) { (_) in }
+        })
     }
 
     private func dissapearSpinnerAnimation(completion: (() -> Void)? = nil) {
@@ -219,6 +219,8 @@ extension AndesButtonAbstractView {
                 self.contentView.transform = CGAffineTransform(translationX: 0, y: 0)
                 self.spinner.alpha = 0
                 self.contentView.alpha = 1
-        }) { (_) in }
+        }) { (_) in
+            completion?()
+        }
     }
 }

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,16 +1,16 @@
 PODS:
-  - AndesUI (3.16.0):
-    - AndesUI/Core (= 3.16.0)
-  - AndesUI/AndesBottomSheet (3.16.0):
+  - AndesUI (3.17.0):
+    - AndesUI/Core (= 3.17.0)
+  - AndesUI/AndesBottomSheet (3.17.0):
     - AndesUI/Core
-  - AndesUI/AndesCoachmark (3.16.0):
+  - AndesUI/AndesCoachmark (3.17.0):
     - AndesUI/Core
-  - AndesUI/AndesDropdown (3.16.0):
+  - AndesUI/AndesDropdown (3.17.0):
     - AndesUI/AndesBottomSheet
     - AndesUI/Core
-  - AndesUI/Core (3.16.0):
+  - AndesUI/Core (3.17.0):
     - AndesUI/LocalIcons
-  - AndesUI/LocalIcons (3.16.0)
+  - AndesUI/LocalIcons (3.17.0)
   - IQKeyboardManagerSwift (6.3.0)
   - Nimble (7.3.4)
   - Quick (1.2.0)
@@ -35,7 +35,7 @@ EXTERNAL SOURCES:
     :path: "./"
 
 SPEC CHECKSUMS:
-  AndesUI: 95718cee7c0096e62705826ad15cb2719d2a6dc5
+  AndesUI: d0ba3c5b0da7604c24b1c9e6869fe6f4c38a5188
   IQKeyboardManagerSwift: a8228c257614af98743b4cd8584637025f36358f
   Nimble: 051e3d8912d40138fa5591c78594f95fb172af37
   Quick: 58d203b1c5e27fff7229c4c1ae445ad7069a7a08


### PR DESCRIPTION
### Thanks for contributing to Andes UI!
## Description
Ajuste para bloques que no soportaban Xcode 11
## Affected component
Andes Button
## RFC Link

## Screenshots / GIFs
<img width="559" alt="image" src="https://user-images.githubusercontent.com/69221534/103312812-2c57e780-49ec-11eb-9373-89580373c985.png">

## Checks
Are you sure you followed all those steps? If so, repeat after me "I solemnly swear that ...":
   - [ ] I have coded an example inside the Demo App,
   - [ ] I have added proper tests,
   - [ ] I have modified the Changelog.md file,
   - [ ] I have updated GitHub wiki,
   - [ ] I have the explicit approval of one or more members of the UX Team,
   - [ ] I have checked that this code is ObjC compliant.
   - [ ] I have checked that all the new public enums conform to AndesEnumStringConvertible.
## Change type
This is easy, let us know what this code is about:
   - [ ] This code adds a new component
   - [x] This code includes improvements to an existent component
   - [ ] This code improves or modifies ONLY the Demo App.
