### PR TITLE
[FIX] - Add safe area to content size calculation in bottom sheet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unpublished
 ### 🚀 Features
 - AndesBottomSheet: Add configurable presentation size | Authors: [@inayabarb](https://github.com/inayabarb)
+- AndesBottomSheet: Fix - Take safe area into account when calculating content size | Authors: [@inayabarb](https://github.com/inayabarb)
 - Added icons to LocalIcons | Authors: [@rbasualdo7](https://github.com/rbasualdo7)
 
 ### 🛠 Bug fixes

--- a/LibraryComponents/Classes/AndesBottomSheet/View/AndesBottomSheetContentViewController.swift
+++ b/LibraryComponents/Classes/AndesBottomSheet/View/AndesBottomSheetContentViewController.swift
@@ -127,7 +127,11 @@ class AndesBottomSheetContentViewController: UIViewController {
         let targetSize = CGSize(width: view.bounds.width, height: UIView.layoutFittingCompressedSize.height)
         let headerSize = headerContentView.systemLayoutSizeFitting(targetSize)
         let contentSize = calculateContentSize()
-        let newSize = CGSize(width: view.bounds.width, height: headerSize.height + contentSize.height)
+        var safeAreaHeight: CGFloat = 0
+        if #available(iOS 11.0, *), let window = UIApplication.shared.keyWindow {
+            safeAreaHeight = window.safeAreaInsets.bottom
+        }
+        let newSize = CGSize(width: view.bounds.width, height: headerSize.height + contentSize.height + safeAreaHeight)
         if newSize != currentSize {
             preferredContentSize = newSize
         }

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,16 +1,16 @@
 PODS:
-  - AndesUI (3.17.0):
-    - AndesUI/Core (= 3.17.0)
-  - AndesUI/AndesBottomSheet (3.17.0):
+  - AndesUI (3.18.1):
+    - AndesUI/Core (= 3.18.1)
+  - AndesUI/AndesBottomSheet (3.18.1):
     - AndesUI/Core
-  - AndesUI/AndesCoachmark (3.17.0):
+  - AndesUI/AndesCoachmark (3.18.1):
     - AndesUI/Core
-  - AndesUI/AndesDropdown (3.17.0):
+  - AndesUI/AndesDropdown (3.18.1):
     - AndesUI/AndesBottomSheet
     - AndesUI/Core
-  - AndesUI/Core (3.17.0):
+  - AndesUI/Core (3.18.1):
     - AndesUI/LocalIcons
-  - AndesUI/LocalIcons (3.17.0)
+  - AndesUI/LocalIcons (3.18.1)
   - IQKeyboardManagerSwift (6.3.0)
   - Nimble (7.3.4)
   - Quick (1.2.0)
@@ -35,7 +35,7 @@ EXTERNAL SOURCES:
     :path: "./"
 
 SPEC CHECKSUMS:
-  AndesUI: d0ba3c5b0da7604c24b1c9e6869fe6f4c38a5188
+  AndesUI: 060db9fe14d456117401c59e80c431c8d42a62db
   IQKeyboardManagerSwift: a8228c257614af98743b4cd8584637025f36358f
   Nimble: 051e3d8912d40138fa5591c78594f95fb172af37
   Quick: 58d203b1c5e27fff7229c4c1ae445ad7069a7a08


### PR DESCRIPTION
### Thanks for contributing to Andes UI!
## Description
Se agrega el tamaño del safe area al calculo de tamaño del contenido del bottom sheet, para evitar un scroll innecesario en dispositivos con safe area.

## Affected component
AndesBottomSheet

## RFC Link
If this change was discussed on RFC please paste link here.
## Screenshots / GIFs
| Antes | Despues |
| ------------- | ------------- |
| ![image](https://user-images.githubusercontent.com/44840744/104370149-2fc79480-54fd-11eb-9a06-b0496405db4c.png) | ![image](https://user-images.githubusercontent.com/44840744/104366846-bd54b580-54f8-11eb-8f64-60ac23b349ba.png) |
| ![image](https://user-images.githubusercontent.com/44840744/104370363-8208b580-54fd-11eb-9135-3ebd13cf7e75.png) | ![image](https://user-images.githubusercontent.com/44840744/104366482-369fd880-54f8-11eb-97ec-4bed30b638c1.png)  |

## Checks
Are you sure you followed all those steps? If so, repeat after me "I solemnly swear that ...":
   - [ ] I have coded an example inside the Demo App,
   - [ ] I have added proper tests,
   - [X] I have modified the Changelog.md file,
   - [ ] I have updated GitHub wiki,
   - [ ] I have the explicit approval of one or more members of the UX Team,
   - [X] I have checked that this code is ObjC compliant.
   - [X] I have checked that all the new public enums conform to AndesEnumStringConvertible.
## Change type
This is easy, let us know what this code is about:
   - [ ] This code adds a new component
   - [X] This code includes improvements to an existent component
   - [ ] This code improves or modifies ONLY the Demo App.
