### PR TITLE
Custom background for Andes Checkbox and Andes Radiobutton

### DIFF
--- a/LibraryComponents/Classes/Core/AndesCheckbox/AndesCheckbox.swift
+++ b/LibraryComponents/Classes/Core/AndesCheckbox/AndesCheckbox.swift
@@ -38,6 +38,20 @@ import UIKit
             self.updateContentView()
         }
     }
+    
+    /// Sets the background color of the AndesCaheckbox , default white
+    @objc public var buttonBackgroundColor: UIColor = .white{
+        didSet {
+            self.updateContentView()
+        }
+    }
+    
+    /// Sets the selected background color of the AndesCaheckbox , default white
+    @objc public var selectedBackgroundColor: UIColor?{
+        didSet {
+            self.updateContentView()
+        }
+    }
 
     /// Callback invoked when checkbox button is tapped
     internal var didTapped: ((AndesCheckbox) -> Void)?
@@ -57,12 +71,14 @@ import UIKit
         setup()
     }
 
-    @objc public init(type: AndesCheckboxType, align: AndesCheckboxAlign, status: AndesCheckboxStatus, title: String) {
+    @objc public init(type: AndesCheckboxType, align: AndesCheckboxAlign, status: AndesCheckboxStatus, title: String, buttonBackgroundColor: UIColor = .white, selectedBackgroundColor: UIColor? = nil) {
         super.init(frame: .zero)
         self.title = title
         self.type = type
         self.align = align
         self.status = status
+        self.buttonBackgroundColor = buttonBackgroundColor
+        self.selectedBackgroundColor = selectedBackgroundColor
         setup()
     }
 

--- a/LibraryComponents/Classes/Core/AndesCheckbox/AndesCheckbox.swift
+++ b/LibraryComponents/Classes/Core/AndesCheckbox/AndesCheckbox.swift
@@ -38,16 +38,16 @@ import UIKit
             self.updateContentView()
         }
     }
-    
+
     /// Sets the background color of the AndesCaheckbox , default white
-    @objc public var buttonBackgroundColor: UIColor = .white{
+    @objc public var buttonBackgroundColor: UIColor = .white {
         didSet {
             self.updateContentView()
         }
     }
-    
+
     /// Sets the selected background color of the AndesCaheckbox , default white
-    @objc public var selectedBackgroundColor: UIColor?{
+    @objc public var selectedBackgroundColor: UIColor? {
         didSet {
             self.updateContentView()
         }
@@ -71,14 +71,12 @@ import UIKit
         setup()
     }
 
-    @objc public init(type: AndesCheckboxType, align: AndesCheckboxAlign, status: AndesCheckboxStatus, title: String, buttonBackgroundColor: UIColor = .white, selectedBackgroundColor: UIColor? = nil) {
+    @objc public init(type: AndesCheckboxType, align: AndesCheckboxAlign, status: AndesCheckboxStatus, title: String) {
         super.init(frame: .zero)
         self.title = title
         self.type = type
         self.align = align
         self.status = status
-        self.buttonBackgroundColor = buttonBackgroundColor
-        self.selectedBackgroundColor = selectedBackgroundColor
         setup()
     }
 

--- a/LibraryComponents/Classes/Core/AndesCheckbox/Config/AndesCheckboxViewConfig.swift
+++ b/LibraryComponents/Classes/Core/AndesCheckbox/Config/AndesCheckboxViewConfig.swift
@@ -21,6 +21,7 @@ internal struct AndesCheckboxViewConfig {
     var borderSize: CGFloat?
     var type: AndesCheckboxTypeProtocol! = AndesCheckboxTypeIdle()
     var status: AndesCheckboxStatusProtocol! = AndesCheckboxStatusUnselected()
+    var buttonBackgroundColor: UIColor = .white
 
     init () { }
 
@@ -35,6 +36,7 @@ internal struct AndesCheckboxViewConfig {
         self.iconColor = self.type.iconColor
         self.borderColor = type.borderColor
         self.borderSize = type.borderSize
-        self.backgroundColor = type.backgroundColor
+        self.backgroundColor = checkbox.selectedBackgroundColor != nil ? checkbox.status == .selected ? checkbox.selectedBackgroundColor! : type.backgroundColor : type.backgroundColor
+        self.buttonBackgroundColor = checkbox.buttonBackgroundColor
     }
 }

--- a/LibraryComponents/Classes/Core/AndesCheckbox/View/AndesCheckboxDefaultView.swift
+++ b/LibraryComponents/Classes/Core/AndesCheckbox/View/AndesCheckboxDefaultView.swift
@@ -71,6 +71,7 @@ class AndesCheckboxDefaultView: UIView, AndesCheckboxView {
         self.addSubview(checkboxView)
         checkboxView.pinToSuperview()
         checkboxView.translatesAutoresizingMaskIntoConstraints = false
+        checkboxView.backgroundColor = config.buttonBackgroundColor
         initialize()
         updateView()
     }

--- a/LibraryComponents/Classes/Core/AndesCheckbox/View/AndesCheckboxDefaultView.swift
+++ b/LibraryComponents/Classes/Core/AndesCheckbox/View/AndesCheckboxDefaultView.swift
@@ -71,7 +71,6 @@ class AndesCheckboxDefaultView: UIView, AndesCheckboxView {
         self.addSubview(checkboxView)
         checkboxView.pinToSuperview()
         checkboxView.translatesAutoresizingMaskIntoConstraints = false
-        checkboxView.backgroundColor = config.buttonBackgroundColor
         initialize()
         updateView()
     }
@@ -84,6 +83,7 @@ class AndesCheckboxDefaultView: UIView, AndesCheckboxView {
     func updateView() {
         clearView()
         self.label.text = config.title
+        checkboxView.backgroundColor = config.buttonBackgroundColor
         updateBoxesViews()
         updateBoxesBorders()
         updateIcons()

--- a/LibraryComponents/Classes/Core/AndesRadioButton/AndesRadioButton.swift
+++ b/LibraryComponents/Classes/Core/AndesRadioButton/AndesRadioButton.swift
@@ -45,6 +45,13 @@ import UIKit
             self.updateContentView()
         }
     }
+    
+    /// Sets the background color of the RadioButton , default white
+    @objc public var buttonBackgroundColor: UIColor = .white{
+        didSet {
+            self.updateContentView()
+        }
+    }
 
     /// Callback invoked when RadioButton  is tapped
     internal var didTapped: ((AndesRadioButton) -> Void)?
@@ -64,12 +71,13 @@ import UIKit
         setup()
     }
 
-    @objc public init(type: AndesRadioButtonType, align: AndesRadioButtonAlign, status: AndesRadioButtonStatus, title: String) {
+    @objc public init(type: AndesRadioButtonType, align: AndesRadioButtonAlign, status: AndesRadioButtonStatus, title: String, buttonBackgroundColor: UIColor = .white) {
         super.init(frame: .zero)
         self.title = title
         self.type = type
         self.align = align
         self.status = status
+        self.buttonBackgroundColor = buttonBackgroundColor
         setup()
     }
 

--- a/LibraryComponents/Classes/Core/AndesRadioButton/AndesRadioButton.swift
+++ b/LibraryComponents/Classes/Core/AndesRadioButton/AndesRadioButton.swift
@@ -45,9 +45,9 @@ import UIKit
             self.updateContentView()
         }
     }
-    
+
     /// Sets the background color of the RadioButton , default white
-    @objc public var buttonBackgroundColor: UIColor = .white{
+    @objc public var buttonBackgroundColor: UIColor = .white {
         didSet {
             self.updateContentView()
         }
@@ -71,13 +71,12 @@ import UIKit
         setup()
     }
 
-    @objc public init(type: AndesRadioButtonType, align: AndesRadioButtonAlign, status: AndesRadioButtonStatus, title: String, buttonBackgroundColor: UIColor = .white) {
+    @objc public init(type: AndesRadioButtonType, align: AndesRadioButtonAlign, status: AndesRadioButtonStatus, title: String) {
         super.init(frame: .zero)
         self.title = title
         self.type = type
         self.align = align
         self.status = status
-        self.buttonBackgroundColor = buttonBackgroundColor
         setup()
     }
 

--- a/LibraryComponents/Classes/Core/AndesRadioButton/Config/AndesRadioButtonConfig.swift
+++ b/LibraryComponents/Classes/Core/AndesRadioButton/Config/AndesRadioButtonConfig.swift
@@ -16,6 +16,7 @@ internal struct AndesRadioButtonConfig {
     var type: AndesRadioButtonTypeProtocol! = AndesRadioButtonTypeIdle()
     var filled: Bool = false
     var titleNumberOfLines: Int?
+    var buttonBackgroundColor: UIColor = .white
 
     init () {
 
@@ -29,5 +30,6 @@ internal struct AndesRadioButtonConfig {
         self.tintColor = type.tintColor
         self.filled = radiobutton.status == .selected && radiobutton.type != .error
         self.titleNumberOfLines = radiobutton.titleNumberOfLines
+        self.buttonBackgroundColor = radiobutton.buttonBackgroundColor
     }
 }

--- a/LibraryComponents/Classes/Core/AndesRadioButton/View/AndesRadioButtonDefaultView.swift
+++ b/LibraryComponents/Classes/Core/AndesRadioButton/View/AndesRadioButtonDefaultView.swift
@@ -70,6 +70,7 @@ class AndesRadioButtonDefaultView: UIView, AndesRadioButtonView {
         radioButtonView.pinToSuperview()
         radioButtonView.translatesAutoresizingMaskIntoConstraints = false
         leftRadioButton.tapCallback = radioButtonTapped
+        radioButtonView.backgroundColor = config.buttonBackgroundColor
         self.radioButtonLabel.isAccessibilityElement = false
         updateView()
     }
@@ -95,6 +96,7 @@ class AndesRadioButtonDefaultView: UIView, AndesRadioButtonView {
             self.labelToLeftButtonConstraint.priority = .defaultHigh
             self.labelToLeadingConstraint.priority = .defaultLow
             self.leftRadioButton.filled = config.filled
+            self.leftRadioButton.backgroundColor = config.buttonBackgroundColor
 
             radiobuttonConstraint = NSLayoutConstraint(item: self.radioButtonLabel!, attribute: .leading, relatedBy: .equal, toItem: self.leftRadioButton!, attribute: .trailing, multiplier: 1, constant: 0)
         } else {
@@ -105,6 +107,7 @@ class AndesRadioButtonDefaultView: UIView, AndesRadioButtonView {
             self.labelToLeftButtonConstraint.priority = .defaultLow
             self.labelToLeadingConstraint.priority = .defaultHigh
             self.rightRadioButton.filled = config.filled
+            self.rightRadioButton.backgroundColor = config.buttonBackgroundColor
 
             radiobuttonConstraint = NSLayoutConstraint(item: self.rightRadioButton!, attribute: .leading, relatedBy: .equal, toItem: radioButtonLabel, attribute: .trailing, multiplier: 1, constant: 0)
         }

--- a/LibraryComponents/Classes/Core/AndesRadioButton/View/AndesRadioButtonDefaultView.swift
+++ b/LibraryComponents/Classes/Core/AndesRadioButton/View/AndesRadioButtonDefaultView.swift
@@ -70,7 +70,6 @@ class AndesRadioButtonDefaultView: UIView, AndesRadioButtonView {
         radioButtonView.pinToSuperview()
         radioButtonView.translatesAutoresizingMaskIntoConstraints = false
         leftRadioButton.tapCallback = radioButtonTapped
-        radioButtonView.backgroundColor = config.buttonBackgroundColor
         self.radioButtonLabel.isAccessibilityElement = false
         updateView()
     }
@@ -79,6 +78,7 @@ class AndesRadioButtonDefaultView: UIView, AndesRadioButtonView {
         self.radioButtonLabel.text = config.title
         self.radioButtonLabel.setAndesStyle(style: AndesStyleSheetManager.styleSheet.bodyM(color: config.textColor))
         self.radioButtonLabel.numberOfLines = config.titleNumberOfLines ?? 0
+        radioButtonView.backgroundColor = config.buttonBackgroundColor
         radioButtonLabel.lineBreakMode = .byTruncatingTail
         setupButtonView()
         updateRadioButtonsStyles()


### PR DESCRIPTION
### Thanks for contributing to Andes UI!
## Description
- Added the possibility of choose background color for Andes Checkbox and Andes Radio Button

Try to answer these questions:
- What is it about?
Customize Andes Checkbox and Andes Radio Button
- How does it work?
You can specify the background color of the Andes Checkbox and Andes Radio Button
## Affected component
Is highly probable that this new code affects directly one (or more?) components inside this lib. Tell us who they are!
- Andes Radio Button
- Andes Checkbox 
## RFC Link
If this change was discussed on RFC please paste link here.
## Screenshots / GIFs
This is a UI library, delight us with some stunning images.
- Before
<img width="545" alt="Captura de Pantalla 2021-01-14 a la(s) 01 08 39" src="https://user-images.githubusercontent.com/49250268/104543815-19a4fb80-5605-11eb-8b90-69914e22e609.png">
- Now
<img width="545" alt="Captura de Pantalla 2021-01-14 a la(s) 00 54 35" src="https://user-images.githubusercontent.com/49250268/104543748-ed897a80-5604-11eb-8165-55d526a5f8f5.png">

## Checks
Are you sure you followed all those steps? If so, repeat after me "I solemnly swear that ...":
   - [ ] I have coded an example inside the Demo App,
   - [ ] I have added proper tests,
   - [ ] I have modified the Changelog.md file,
   - [ ] I have updated GitHub wiki,
   - [ ] I have the explicit approval of one or more members of the UX Team,
   - [ ] I have checked that this code is ObjC compliant.
   - [ ] I have checked that all the new public enums conform to AndesEnumStringConvertible.
## Change type
This is easy, let us know what this code is about:
   - [ ] This code adds a new component
   - [x] This code includes improvements to an existent component
   - [ ] This code improves or modifies ONLY the Demo App.
