### PR TITLE
SinglePlayer Pos - Fix/SPSA-328

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 ### 🚀 Features
 - Added icons to LocalIcons | Authors: [@rbasualdo7](https://github.com/rbasualdo7)
 
+### 🛠 Bug fixes
+- DatePicker: Fix calendar back button | Authors: [@AndriuCoelho](https://github.com/AndriuCoelho)
+
 # v3.19.0
 ### 🚀 Features
 - AndesBottomSheet: Add configurable presentation size | Authors: [@inayabarb](https://github.com/inayabarb)

--- a/Example/AndesUI.xcodeproj/project.pbxproj
+++ b/Example/AndesUI.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		023ADCEC24ACD4050076C3F3 /* ThumbnailObjCViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 023ADCEA24ACD4050076C3F3 /* ThumbnailObjCViewController.m */; };
 		023ADCED24ACD4050076C3F3 /* ThumbnailObjCViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 023ADCEB24ACD4050076C3F3 /* ThumbnailObjCViewController.xib */; };
 		02683A5B24B36E1000C3FD9A /* AndesThumbnailTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02683A5A24B36E1000C3FD9A /* AndesThumbnailTests.swift */; };
+		0304F4D425C0B73300A6BA72 /* AndesDatePickerHeaderViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0304F4D325C0B73300A6BA72 /* AndesDatePickerHeaderViewTests.swift */; };
 		0323A40E25607FC6001A480F /* DatePickerRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0323A40D25607FC6001A480F /* DatePickerRouter.swift */; };
 		0323A414256085A2001A480F /* DatePickerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0323A412256085A2001A480F /* DatePickerViewController.swift */; };
 		0323A415256085A2001A480F /* DatePickerViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 0323A413256085A2001A480F /* DatePickerViewController.xib */; };
@@ -192,6 +193,7 @@
 		023ADCEA24ACD4050076C3F3 /* ThumbnailObjCViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ThumbnailObjCViewController.m; sourceTree = "<group>"; };
 		023ADCEB24ACD4050076C3F3 /* ThumbnailObjCViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ThumbnailObjCViewController.xib; sourceTree = "<group>"; };
 		02683A5A24B36E1000C3FD9A /* AndesThumbnailTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AndesThumbnailTests.swift; sourceTree = "<group>"; };
+		0304F4D325C0B73300A6BA72 /* AndesDatePickerHeaderViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AndesDatePickerHeaderViewTests.swift; sourceTree = "<group>"; };
 		0323A40D25607FC6001A480F /* DatePickerRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatePickerRouter.swift; sourceTree = "<group>"; };
 		0323A412256085A2001A480F /* DatePickerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatePickerViewController.swift; sourceTree = "<group>"; };
 		0323A413256085A2001A480F /* DatePickerViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = DatePickerViewController.xib; sourceTree = "<group>"; };
@@ -469,6 +471,7 @@
 			children = (
 				034D60122563E6AB00978518 /* AndesDatePickerAbstractViewTests.swift */,
 				034D60142563F08300978518 /* AndesDayDatePickerTests.swift */,
+				0304F4D325C0B73300A6BA72 /* AndesDatePickerHeaderViewTests.swift */,
 			);
 			name = DatePicker;
 			sourceTree = "<group>";
@@ -1500,6 +1503,7 @@
 				9C592C0C2450A6B70038785E /* AndesTextFieldSideComponentTests.swift in Sources */,
 				80D6915924EC0E98002CF3BC /* AndesCoachmarkNavBarTests.swift in Sources */,
 				80D6914F24E438C2002CF3BC /* MockSwift.swift in Sources */,
+				0304F4D425C0B73300A6BA72 /* AndesDatePickerHeaderViewTests.swift in Sources */,
 				F85E052324AF79900059C6FA /* AndesRadioButtonTest.swift in Sources */,
 				80D6915124E449B0002CF3BC /* AndesCoachmarkViewMock.swift in Sources */,
 				9CAD81E923FD66ED00D43EB9 /* AndesIconsProviderTests.swift in Sources */,

--- a/Example/Tests/AndesDatePickerHeaderViewTests.swift
+++ b/Example/Tests/AndesDatePickerHeaderViewTests.swift
@@ -1,0 +1,53 @@
+//
+//  AndesDatePickerHeaderViewTests.swift
+//  AndesUI_Tests
+//
+//  Created by Ândriu Felipe Coelho on 26/01/21.
+//  Copyright © 2021 MercadoLibre. All rights reserved.
+//
+
+import Quick
+import Nimble
+
+@testable import AndesUI
+
+class AndesDatePickerHeaderViewTests: QuickSpec {
+
+    var internalView: AndesDatePickerHeaderView!
+
+    override func spec() {
+
+        beforeEach {
+            self.internalView = AndesDatePickerHeaderView()
+        }
+
+        afterEach {
+            self.internalView = AndesDatePickerHeaderView()
+        }
+
+        describe("Test: checks if the collection view is set up correctly") {
+            context("verify class") {
+
+                it("collectionview data source should not be nil") {
+                    expect(self.internalView).toNot(beNil())
+                }
+
+                it("passing a due date, the back button must be disabled (for the current month)") {
+                    let andesPicker = AndesDatePickerDefaultView()
+                    andesPicker.setDates(maxDate: Calendar.current.date(from: DateComponents(year: 2021, month: 2, day: 07)))
+
+                    guard let currentDate = Calendar.current.date(from: DateComponents(year: 2021, month: 1, day: 27)) else {
+                        fatalError("error to create date")
+                    }
+
+                    let daysToRender = andesPicker.dayCalendar.getDaysInMonth(currentDate, Date())
+
+                    self.internalView.togglePreviousButton(days: daysToRender)
+
+                    expect(self.internalView.previousButton.isEnabled).to(beFalse())
+                }
+            }
+        }
+    }
+
+}

--- a/LibraryComponents/Classes/Core/AndesDatePicker/View/AndesDatePickerHeaderView.swift
+++ b/LibraryComponents/Classes/Core/AndesDatePicker/View/AndesDatePickerHeaderView.swift
@@ -150,7 +150,8 @@ class AndesDatePickerHeaderView: UICollectionReusableView {
     func togglePreviousButton(days: [AndesDayDatePicker]) {
         previousButton.isEnabled = true
         for day in days {
-            if day.isCurrentMonth && day.dueDate != nil {
+            let datesAreInTheSameMonth = Calendar.current.isDate(day.date, equalTo: Date(), toGranularity: .month)
+            if datesAreInTheSameMonth && day.dueDate != nil {
                 previousButton.isEnabled = false
                 break
             }

--- a/LibraryComponents/Classes/Core/AndesDatePicker/View/AndesDatePickerHeaderView.swift
+++ b/LibraryComponents/Classes/Core/AndesDatePicker/View/AndesDatePickerHeaderView.swift
@@ -59,7 +59,7 @@ class AndesDatePickerHeaderView: UICollectionReusableView {
         return label
     }()
 
-    private let previousButton: UIButton = {
+    let previousButton: UIButton = {
         let button = UIButton(type: .custom)
         button.translatesAutoresizingMaskIntoConstraints = false
         button.addTarget(self, action: #selector(didTouchPreviousMonth), for: .touchUpInside)

--- a/LibraryComponents/Classes/Core/AndesDatePicker/View/AndesDatePickerHeaderView.swift
+++ b/LibraryComponents/Classes/Core/AndesDatePicker/View/AndesDatePickerHeaderView.swift
@@ -59,7 +59,7 @@ class AndesDatePickerHeaderView: UICollectionReusableView {
         return label
     }()
 
-    let previousButton: UIButton = {
+    private(set) var previousButton: UIButton = {
         let button = UIButton(type: .custom)
         button.translatesAutoresizingMaskIntoConstraints = false
         button.addTarget(self, action: #selector(didTouchPreviousMonth), for: .touchUpInside)


### PR DESCRIPTION
### Thanks for contributing to Andes UI!
## Description
- Bug fix in the back button of the date picker 
Try to answer these questions:
- What is it about?
- When we started the date picker passing an expiration date, the component would not let us go back to the previous months
- How does it work?
## Affected component
No!
## RFC Link
If this change was discussed on RFC please paste link here.
## Screenshots / GIFs
![calendario](https://user-images.githubusercontent.com/7536739/105900623-11808f00-5ffb-11eb-84b0-810c6a85d82c.gif)
## Checks
Are you sure you followed all those steps? If so, repeat after me "I solemnly swear that ...":
   - [ ] I have coded an example inside the Demo App,
   - [ ] I have added proper tests,
   - [ ] I have modified the Changelog.md file,
   - [ ] I have updated GitHub wiki,
   - [ ] I have the explicit approval of one or more members of the UX Team,
   - [ ] I have checked that this code is ObjC compliant.
   - [ ] I have checked that all the new public enums conform to AndesEnumStringConvertible.
## Change type
This is easy, let us know what this code is about:
   - [ ] This code adds a new component
   - [ ] This code includes improvements to an existent component
   - [ ] This code improves or modifies ONLY the Demo App.
