### PR TITLE
Custom background for Andes Checkbox and Andes Radiobutton

### DIFF
--- a/Example/AndesUI/Checkbox/Views/AndesCheckboxInitViewController.swift
+++ b/Example/AndesUI/Checkbox/Views/AndesCheckboxInitViewController.swift
@@ -14,12 +14,16 @@ class AndesCheckboxInitViewController: UIViewController {
     var typePicker: UIPickerView = UIPickerView()
     var statusPicker: UIPickerView = UIPickerView()
     var alignPicker: UIPickerView = UIPickerView()
+    var bgcolorPicker: UIPickerView = UIPickerView()
+    var fillColorPicker: UIPickerView = UIPickerView()
 
     @IBOutlet weak var andesCheckbox: AndesCheckbox!
     @IBOutlet weak var typeTxt: UITextField!
     @IBOutlet weak var statusTxt: UITextField!
     @IBOutlet weak var alignTxt: UITextField!
     @IBOutlet weak var checkboxTxt: UITextField!
+    @IBOutlet weak var buttonBGColorTxt: UITextField!
+    @IBOutlet weak var fillColorTxt: UITextField!
 
     @IBOutlet weak var updateBtn: UIButton!
     @IBOutlet weak var clearBtn: UIButton!
@@ -43,6 +47,16 @@ class AndesCheckboxInitViewController: UIViewController {
         alignPicker.delegate = self
         alignPicker.dataSource = self
         alignTxt.text = self.andesCheckbox.align.toString()
+
+        buttonBGColorTxt.inputView = bgcolorPicker
+        bgcolorPicker.delegate = self
+        bgcolorPicker.dataSource = self
+        buttonBGColorTxt.text = "Default"
+
+        fillColorTxt.inputView = fillColorPicker
+        fillColorPicker.delegate = self
+        fillColorPicker.dataSource = self
+        fillColorTxt.text = "Default"
     }
 
     @IBAction func updateTapped(_ sender: Any) {
@@ -54,10 +68,14 @@ class AndesCheckboxInitViewController: UIViewController {
         self.andesCheckbox.type = AndesCheckboxType.idle
         self.andesCheckbox.status = AndesCheckboxStatus.unselected
         self.andesCheckbox.align = AndesCheckboxAlign.left
+        self.andesCheckbox.buttonBackgroundColor = .white
+        self.andesCheckbox.selectedBackgroundColor = nil
 
         typeTxt.text = self.andesCheckbox.type.toString()
         statusTxt.text = self.andesCheckbox.status.toString()
         alignTxt.text = self.andesCheckbox.align.toString()
+        buttonBGColorTxt.text = "Default"
+        fillColorTxt.text = "Default"
 
         checkboxTxt.text = ""
     }
@@ -92,6 +110,44 @@ extension AndesCheckboxInitViewController: UIPickerViewDelegate {
             self.andesCheckbox.align = AndesCheckboxAlign.init(rawValue: row)!
             alignTxt.text = self.andesCheckbox.align.toString()
         }
+        if pickerView == bgcolorPicker {
+            buttonBGColorTxt.resignFirstResponder()
+            if row == 0 {
+                self.andesCheckbox.buttonBackgroundColor = .white
+                buttonBGColorTxt.text = "Default"
+            }
+            if row == 1 {
+                self.andesCheckbox.buttonBackgroundColor = .yellow
+                buttonBGColorTxt.text = "Yellow"
+            }
+            if row == 2 {
+                self.andesCheckbox.buttonBackgroundColor = .blue
+                buttonBGColorTxt.text = "Blue"
+            }
+            if row == 3 {
+                self.andesCheckbox.buttonBackgroundColor = .clear
+                buttonBGColorTxt.text = "Clear"
+            }
+        }
+        if pickerView == fillColorPicker {
+            fillColorTxt.resignFirstResponder()
+            if row == 0 {
+                self.andesCheckbox.selectedBackgroundColor = nil
+                fillColorTxt.text = "Default"
+            }
+            if row == 1 {
+                self.andesCheckbox.selectedBackgroundColor = .yellow
+                fillColorTxt.text = "Yellow"
+            }
+            if row == 2 {
+                self.andesCheckbox.selectedBackgroundColor = .blue
+                fillColorTxt.text = "Blue"
+            }
+            if row == 3 {
+                self.andesCheckbox.selectedBackgroundColor = .clear
+                fillColorTxt.text = "Clear"
+            }
+        }
     }
 }
 
@@ -105,6 +161,12 @@ extension AndesCheckboxInitViewController: UIPickerViewDataSource {
         }
         if pickerView == alignPicker {
             return 2
+        }
+        if pickerView == bgcolorPicker {
+            return 4
+        }
+        if pickerView == fillColorPicker {
+            return 4
         }
         return 0
     }
@@ -126,6 +188,20 @@ extension AndesCheckboxInitViewController: UIPickerViewDataSource {
         if pickerView == alignPicker {
              let align = AndesCheckboxAlign.init(rawValue: row)!
             return align.toString()
+        }
+        if pickerView == bgcolorPicker || pickerView == fillColorPicker {
+            switch row {
+            case 0:
+                return "Default"
+            case 1:
+                return "Yellow"
+            case 2:
+                return "Blue"
+            case 3:
+                return "Clear"
+            default:
+                return ""
+            }
         }
         return ""
     }

--- a/Example/AndesUI/Checkbox/Views/AndesCheckboxInitViewController.xib
+++ b/Example/AndesUI/Checkbox/Views/AndesCheckboxInitViewController.xib
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15705" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15706"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17125"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -12,8 +13,10 @@
             <connections>
                 <outlet property="alignTxt" destination="cff-8u-jgz" id="R8k-X8-EXE"/>
                 <outlet property="andesCheckbox" destination="pOA-yv-0Vh" id="7ZD-jW-OAc"/>
+                <outlet property="buttonBGColorTxt" destination="ZsR-jA-7q0" id="Rz6-6n-XVi"/>
                 <outlet property="checkboxTxt" destination="qML-IJ-byS" id="Aox-Jh-cwN"/>
                 <outlet property="clearBtn" destination="ord-lb-YFR" id="VjV-Hq-H4Q"/>
+                <outlet property="fillColorTxt" destination="sr6-by-Tmk" id="ANf-lq-Y9W"/>
                 <outlet property="statusTxt" destination="Ts1-yY-rue" id="4w9-9c-oEt"/>
                 <outlet property="typeTxt" destination="udn-1a-2Pn" id="4Dy-Ov-0fL"/>
                 <outlet property="updateBtn" destination="vMl-m8-3vz" id="TL0-LL-v4J"/>
@@ -26,7 +29,7 @@
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="avQ-9z-Y18">
-                    <rect key="frame" x="50" y="120" width="314" height="442"/>
+                    <rect key="frame" x="50" y="120" width="314" height="524"/>
                     <subviews>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Type" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="16e-Iu-BAB">
                             <rect key="frame" x="0.0" y="143" width="37.5" height="21"/>
@@ -35,13 +38,25 @@
                             <nil key="highlightedColor"/>
                         </label>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Status" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xP0-qj-BMd">
-                            <rect key="frame" x="0.0" y="184" width="49.5" height="21"/>
+                            <rect key="frame" x="0.0" y="184" width="49" height="21"/>
                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                             <nil key="textColor"/>
                             <nil key="highlightedColor"/>
                         </label>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Align" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ktu-Z2-Sok">
                             <rect key="frame" x="0.0" y="225" width="38.5" height="21"/>
+                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                            <nil key="textColor"/>
+                            <nil key="highlightedColor"/>
+                        </label>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Background Color" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3cU-Tl-AE5">
+                            <rect key="frame" x="0.0" y="266" width="137" height="21"/>
+                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                            <nil key="textColor"/>
+                            <nil key="highlightedColor"/>
+                        </label>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Fill Color" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hh6-dy-mjH">
+                            <rect key="frame" x="0.0" y="307" width="67" height="21"/>
                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                             <nil key="textColor"/>
                             <nil key="highlightedColor"/>
@@ -70,28 +85,43 @@
                             <fontDescription key="fontDescription" type="system" pointSize="14"/>
                             <textInputTraits key="textInputTraits"/>
                         </textField>
-                        <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Checkbox text" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="qML-IJ-byS">
-                            <rect key="frame" x="8" y="273" width="298" height="34"/>
+                        <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="bg color" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="ZsR-jA-7q0">
+                            <rect key="frame" x="178" y="259.5" width="136" height="34"/>
+                            <constraints>
+                                <constraint firstAttribute="width" secondItem="ZsR-jA-7q0" secondAttribute="height" multiplier="4:1" id="p90-ZA-Tpm"/>
+                            </constraints>
                             <fontDescription key="fontDescription" type="system" pointSize="14"/>
                             <textInputTraits key="textInputTraits"/>
                         </textField>
-                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="vMl-m8-3vz">
-                            <rect key="frame" x="8" y="327" width="51" height="30"/>
+                        <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Checkbox text" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="qML-IJ-byS">
+                            <rect key="frame" x="8" y="355" width="298" height="34"/>
+                            <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                            <textInputTraits key="textInputTraits"/>
+                        </textField>
+                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="vMl-m8-3vz">
+                            <rect key="frame" x="8" y="409" width="51" height="30"/>
                             <state key="normal" title="Update"/>
                             <connections>
                                 <action selector="updateTapped:" destination="-1" eventType="touchUpInside" id="o92-gd-Gmn"/>
                             </connections>
                         </button>
-                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ord-lb-YFR">
-                            <rect key="frame" x="270" y="327" width="36" height="30"/>
+                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ord-lb-YFR">
+                            <rect key="frame" x="270" y="409" width="36" height="30"/>
                             <state key="normal" title="Clear"/>
                             <connections>
                                 <action selector="clearTapped:" destination="-1" eventType="touchUpInside" id="6hl-oF-dM3"/>
                             </connections>
                         </button>
+                        <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="fill color" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="sr6-by-Tmk">
+                            <rect key="frame" x="178" y="300.5" width="136" height="34"/>
+                            <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                            <textInputTraits key="textInputTraits"/>
+                        </textField>
                     </subviews>
                     <constraints>
                         <constraint firstItem="udn-1a-2Pn" firstAttribute="centerY" secondItem="16e-Iu-BAB" secondAttribute="centerY" id="0Mx-Qk-ATu"/>
+                        <constraint firstAttribute="trailing" secondItem="ZsR-jA-7q0" secondAttribute="trailing" id="21f-Vo-s2n"/>
+                        <constraint firstItem="qML-IJ-byS" firstAttribute="top" secondItem="hh6-dy-mjH" secondAttribute="bottom" constant="27" id="24I-WI-ZoB"/>
                         <constraint firstItem="ktu-Z2-Sok" firstAttribute="leading" secondItem="avQ-9z-Y18" secondAttribute="leading" id="51r-g7-IxH"/>
                         <constraint firstItem="vMl-m8-3vz" firstAttribute="leading" secondItem="avQ-9z-Y18" secondAttribute="leading" constant="8" id="5aD-ce-jJQ"/>
                         <constraint firstItem="xP0-qj-BMd" firstAttribute="top" secondItem="16e-Iu-BAB" secondAttribute="bottom" constant="20" id="6Sg-6M-7ES"/>
@@ -102,23 +132,32 @@
                         <constraint firstItem="ktu-Z2-Sok" firstAttribute="top" secondItem="xP0-qj-BMd" secondAttribute="bottom" constant="20" id="ChM-pE-P7t"/>
                         <constraint firstAttribute="trailing" secondItem="udn-1a-2Pn" secondAttribute="trailing" id="Dbr-Rd-Pcw"/>
                         <constraint firstItem="16e-Iu-BAB" firstAttribute="top" secondItem="avQ-9z-Y18" secondAttribute="top" constant="143" id="GME-Ik-Ryx"/>
+                        <constraint firstAttribute="trailing" secondItem="sr6-by-Tmk" secondAttribute="trailing" id="Iza-uI-vwu"/>
+                        <constraint firstItem="sr6-by-Tmk" firstAttribute="width" secondItem="sr6-by-Tmk" secondAttribute="height" multiplier="4:1" id="JbU-iT-jfk"/>
                         <constraint firstAttribute="trailing" secondItem="Ts1-yY-rue" secondAttribute="trailing" id="Li0-1a-jUv"/>
+                        <constraint firstItem="ZsR-jA-7q0" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="3cU-Tl-AE5" secondAttribute="trailing" constant="10" id="Ljx-tZ-MiQ"/>
+                        <constraint firstItem="hh6-dy-mjH" firstAttribute="top" secondItem="3cU-Tl-AE5" secondAttribute="bottom" constant="20" id="Qoe-aS-AZR"/>
                         <constraint firstAttribute="bottom" secondItem="vMl-m8-3vz" secondAttribute="bottom" constant="85" id="Rga-Jm-ZbN"/>
+                        <constraint firstItem="3cU-Tl-AE5" firstAttribute="top" secondItem="ktu-Z2-Sok" secondAttribute="bottom" constant="20" id="ZdS-jw-OIz"/>
+                        <constraint firstItem="sr6-by-Tmk" firstAttribute="centerY" secondItem="hh6-dy-mjH" secondAttribute="centerY" id="afp-7c-hG2"/>
                         <constraint firstItem="cff-8u-jgz" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="ktu-Z2-Sok" secondAttribute="trailing" constant="10" id="bJ0-P0-f1E"/>
-                        <constraint firstItem="qML-IJ-byS" firstAttribute="top" secondItem="ktu-Z2-Sok" secondAttribute="bottom" constant="27" id="fsc-6U-Qon"/>
+                        <constraint firstItem="hh6-dy-mjH" firstAttribute="leading" secondItem="avQ-9z-Y18" secondAttribute="leading" id="cLm-pS-5mw"/>
                         <constraint firstItem="Ts1-yY-rue" firstAttribute="centerY" secondItem="xP0-qj-BMd" secondAttribute="centerY" id="hPZ-Iz-HHh"/>
                         <constraint firstItem="cff-8u-jgz" firstAttribute="centerY" secondItem="ktu-Z2-Sok" secondAttribute="centerY" id="hud-DR-wVg"/>
                         <constraint firstAttribute="trailing" secondItem="cff-8u-jgz" secondAttribute="trailing" id="jDe-Ou-A2Q"/>
                         <constraint firstItem="Ts1-yY-rue" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="xP0-qj-BMd" secondAttribute="trailing" constant="10" id="jhR-4r-QJV"/>
                         <constraint firstItem="ord-lb-YFR" firstAttribute="top" secondItem="qML-IJ-byS" secondAttribute="bottom" constant="20" id="lBU-tX-2Mn"/>
+                        <constraint firstItem="sr6-by-Tmk" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="hh6-dy-mjH" secondAttribute="trailing" constant="10" id="ljw-5d-ZY5"/>
+                        <constraint firstItem="3cU-Tl-AE5" firstAttribute="leading" secondItem="avQ-9z-Y18" secondAttribute="leading" id="oxz-yb-Bit"/>
                         <constraint firstItem="qML-IJ-byS" firstAttribute="leading" secondItem="avQ-9z-Y18" secondAttribute="leading" constant="8" id="pV8-dB-o29"/>
                         <constraint firstAttribute="trailing" secondItem="ord-lb-YFR" secondAttribute="trailing" constant="8" id="qRX-mc-Wb2"/>
                         <constraint firstItem="vMl-m8-3vz" firstAttribute="top" secondItem="qML-IJ-byS" secondAttribute="bottom" constant="20" id="rWP-6o-aKC"/>
+                        <constraint firstItem="ZsR-jA-7q0" firstAttribute="centerY" secondItem="3cU-Tl-AE5" secondAttribute="centerY" id="wcy-LK-xWV"/>
                     </constraints>
                 </view>
                 <view contentMode="scaleToFill" placeholderIntrinsicWidth="150" placeholderIntrinsicHeight="50" translatesAutoresizingMaskIntoConstraints="NO" id="pOA-yv-0Vh" customClass="AndesCheckbox" customModule="AndesUI">
                     <rect key="frame" x="132" y="174" width="150" height="50"/>
-                    <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                     <userDefinedRuntimeAttributes>
                         <userDefinedRuntimeAttribute type="string" keyPath="title" value="Andes Checkbox"/>
                         <userDefinedRuntimeAttribute type="string" keyPath="ibType" value="idle"/>
@@ -127,6 +166,7 @@
                     </userDefinedRuntimeAttributes>
                 </view>
             </subviews>
+            <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
             <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
             <constraints>
                 <constraint firstItem="avQ-9z-Y18" firstAttribute="top" secondItem="vUN-kp-3ea" secondAttribute="top" constant="76" id="QA5-Qi-yMA"/>
@@ -137,8 +177,12 @@
                 <constraint firstItem="avQ-9z-Y18" firstAttribute="centerX" secondItem="vUN-kp-3ea" secondAttribute="centerX" id="oaA-Yc-X4n"/>
                 <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="avQ-9z-Y18" secondAttribute="trailing" constant="50" id="rpK-fM-XEc"/>
             </constraints>
-            <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
             <point key="canvasLocation" x="137.68115942028987" y="108.48214285714285"/>
         </view>
     </objects>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
 </document>

--- a/Example/AndesUI/Checkbox/Views/CheckboxObjCViewController.xib
+++ b/Example/AndesUI/Checkbox/Views/CheckboxObjCViewController.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15705" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15706"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17125"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -23,6 +23,7 @@
                     <rect key="frame" x="0.0" y="49" width="414" height="799"/>
                 </stackView>
             </subviews>
+            <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
             <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
             <constraints>
                 <constraint firstItem="vUN-kp-3ea" firstAttribute="bottom" secondItem="5LJ-wv-VO2" secondAttribute="bottom" constant="14" id="1FU-3o-1xw"/>
@@ -31,7 +32,6 @@
                 <constraint firstItem="5LJ-wv-VO2" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" id="QsX-lM-5iF"/>
                 <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="5LJ-wv-VO2" secondAttribute="trailing" id="eGH-0q-gxL"/>
             </constraints>
-            <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
             <point key="canvasLocation" x="139" y="137"/>
         </view>
     </objects>

--- a/Example/AndesUI/RadioButton/Views/AndesRadioButtonViewController.swift
+++ b/Example/AndesUI/RadioButton/Views/AndesRadioButtonViewController.swift
@@ -20,6 +20,7 @@ class AndesRadioButtonViewController: UIViewController, RadioButtonView {
     @IBOutlet weak var alignTxt: UITextField!
     @IBOutlet weak var radioButtonTxt: UITextField!
     @IBOutlet weak var numberLinesTxt: UITextField!
+    @IBOutlet weak var buttonBGColorTxt: UITextField!
 
     @IBOutlet weak var updateBtn: UIButton!
     @IBOutlet weak var clearBtn: UIButton!
@@ -27,6 +28,7 @@ class AndesRadioButtonViewController: UIViewController, RadioButtonView {
     var typePicker: UIPickerView = UIPickerView()
     var statusPicker: UIPickerView = UIPickerView()
     var alignPicker: UIPickerView = UIPickerView()
+    var bgcolorPicker: UIPickerView = UIPickerView()
 
     @IBOutlet weak var radioButton: AndesRadioButton!
 
@@ -50,10 +52,12 @@ class AndesRadioButtonViewController: UIViewController, RadioButtonView {
         self.radioButton.type = .idle
         self.radioButton.status = .unselected
         self.radioButton.align = .left
+        self.radioButton.buttonBackgroundColor = .white
 
         typeText.text = self.radioButton.type.toString()
         statusTxt.text = self.radioButton.status.toString()
         alignTxt.text = self.radioButton.align.toString()
+        buttonBGColorTxt.text = "Default"
         numberLinesTxt.text = "0"
 
         radioButtonTxt.text = ""
@@ -74,6 +78,11 @@ class AndesRadioButtonViewController: UIViewController, RadioButtonView {
         alignPicker.delegate = self
         alignPicker.dataSource = self
         alignTxt.text = self.radioButton.align.toString()
+
+        buttonBGColorTxt.inputView = bgcolorPicker
+        bgcolorPicker.delegate = self
+        bgcolorPicker.dataSource = self
+        buttonBGColorTxt.text = "Default"
     }
 
     func didTapIdle(radiobutton: AndesRadioButton) {
@@ -114,6 +123,25 @@ extension AndesRadioButtonViewController: UIPickerViewDelegate {
             self.radioButton.align = AndesRadioButtonAlign.init(rawValue: row)!
             alignTxt.text = self.radioButton.align.toString()
         }
+        if pickerView == bgcolorPicker {
+            buttonBGColorTxt.resignFirstResponder()
+            if row == 0 {
+                self.radioButton.buttonBackgroundColor = .white
+                buttonBGColorTxt.text = "Default"
+            }
+            if row == 1 {
+                self.radioButton.buttonBackgroundColor = .yellow
+                buttonBGColorTxt.text = "Yellow"
+            }
+            if row == 2 {
+                self.radioButton.buttonBackgroundColor = .blue
+                buttonBGColorTxt.text = "Blue"
+            }
+            if row == 3 {
+                self.radioButton.buttonBackgroundColor = .clear
+                buttonBGColorTxt.text = "Clear"
+            }
+        }
     }
 }
 
@@ -127,6 +155,9 @@ extension AndesRadioButtonViewController: UIPickerViewDataSource {
         }
         if pickerView == alignPicker {
             return 2
+        }
+        if pickerView == bgcolorPicker {
+            return 4
         }
         return 0
     }
@@ -148,6 +179,20 @@ extension AndesRadioButtonViewController: UIPickerViewDataSource {
         if pickerView == alignPicker {
              let align = AndesRadioButtonAlign.init(rawValue: row)!
             return align.toString()
+        }
+        if pickerView == bgcolorPicker {
+            switch row {
+            case 0:
+                return "Default"
+            case 1:
+                return "Yellow"
+            case 2:
+                return "Blue"
+            case 3:
+                return "Clear"
+            default:
+                return ""
+            }
         }
         return ""
     }

--- a/Example/AndesUI/RadioButton/Views/AndesRadioButtonViewController.xib
+++ b/Example/AndesUI/RadioButton/Views/AndesRadioButtonViewController.xib
@@ -3,7 +3,7 @@
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17126"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17125"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -12,6 +12,7 @@
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="AndesRadioButtonViewController" customModule="AndesUI_DemoApp" customModuleProvider="target">
             <connections>
                 <outlet property="alignTxt" destination="LCw-QB-Mfv" id="ptX-m3-Wwg"/>
+                <outlet property="buttonBGColorTxt" destination="Mdu-me-PxK" id="ew7-kv-3b1"/>
                 <outlet property="clearBtn" destination="jAR-mm-eeW" id="HiL-mP-l2v"/>
                 <outlet property="numberLinesTxt" destination="wIw-6s-vyh" id="INt-VL-AwJ"/>
                 <outlet property="radioButton" destination="zhE-sd-tpD" id="DpP-qY-LKm"/>
@@ -28,7 +29,7 @@
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="4bW-nu-PyM">
-                    <rect key="frame" x="50" y="74" width="314" height="476"/>
+                    <rect key="frame" x="50" y="74" width="314" height="517"/>
                     <subviews>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Type" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Rkj-iL-29z">
                             <rect key="frame" x="0.0" y="143" width="37.5" height="21"/>
@@ -73,14 +74,14 @@
                             <textInputTraits key="textInputTraits"/>
                         </textField>
                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="QmN-5v-7sp">
-                            <rect key="frame" x="8" y="361" width="51" height="30"/>
+                            <rect key="frame" x="8" y="402" width="51" height="30"/>
                             <state key="normal" title="Update"/>
                             <connections>
                                 <action selector="updateTapped:" destination="-1" eventType="touchUpInside" id="doT-su-8nS"/>
                             </connections>
                         </button>
                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="jAR-mm-eeW">
-                            <rect key="frame" x="270" y="361" width="36" height="30"/>
+                            <rect key="frame" x="270" y="402" width="36" height="30"/>
                             <state key="normal" title="Clear"/>
                             <connections>
                                 <action selector="clearTapped:" destination="-1" eventType="touchUpInside" id="rJX-3F-wfW"/>
@@ -102,6 +103,12 @@
                             <nil key="textColor"/>
                             <nil key="highlightedColor"/>
                         </label>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Button BG Color" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="YeC-xf-euf">
+                            <rect key="frame" x="0.0" y="307" width="123.5" height="21"/>
+                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                            <nil key="textColor"/>
+                            <nil key="highlightedColor"/>
+                        </label>
                         <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="0" borderStyle="roundedRect" placeholder="number of lines" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="wIw-6s-vyh">
                             <rect key="frame" x="244" y="259.5" width="70" height="34"/>
                             <constraints>
@@ -111,7 +118,12 @@
                             <textInputTraits key="textInputTraits" keyboardType="numberPad"/>
                         </textField>
                         <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Checkbox text" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="RnL-ig-JUl" userLabel="radiobutton text">
-                            <rect key="frame" x="8" y="307" width="298" height="34"/>
+                            <rect key="frame" x="8" y="348" width="298" height="34"/>
+                            <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                            <textInputTraits key="textInputTraits"/>
+                        </textField>
+                        <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="checkbox bg color" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="Mdu-me-PxK" userLabel="radiobbuton align">
+                            <rect key="frame" x="166.5" y="299" width="147.5" height="37"/>
                             <fontDescription key="fontDescription" type="system" pointSize="14"/>
                             <textInputTraits key="textInputTraits"/>
                         </textField>
@@ -119,22 +131,27 @@
                     <constraints>
                         <constraint firstItem="qgF-MF-lth" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="Rkj-iL-29z" secondAttribute="trailing" constant="10" id="0i5-6e-QKP"/>
                         <constraint firstAttribute="trailing" secondItem="hYw-3i-glO" secondAttribute="trailing" id="27O-71-JRg"/>
+                        <constraint firstItem="YeC-xf-euf" firstAttribute="leading" secondItem="4bW-nu-PyM" secondAttribute="leading" id="2BX-Br-jzx"/>
                         <constraint firstItem="wIw-6s-vyh" firstAttribute="centerY" secondItem="kRM-oh-Ikv" secondAttribute="centerY" id="2OH-Jb-IFQ"/>
                         <constraint firstItem="8ga-Fs-LXn" firstAttribute="leading" secondItem="4bW-nu-PyM" secondAttribute="leading" id="3U3-aB-K48"/>
+                        <constraint firstItem="Mdu-me-PxK" firstAttribute="centerY" secondItem="YeC-xf-euf" secondAttribute="centerY" id="88x-7R-Dya"/>
                         <constraint firstAttribute="trailing" secondItem="jAR-mm-eeW" secondAttribute="trailing" constant="8" id="8ab-lQ-LFr"/>
                         <constraint firstItem="Rkj-iL-29z" firstAttribute="leading" secondItem="4bW-nu-PyM" secondAttribute="leading" id="ATt-Yo-mQX"/>
                         <constraint firstItem="RnL-ig-JUl" firstAttribute="leading" secondItem="4bW-nu-PyM" secondAttribute="leading" constant="8" id="AUp-0n-CU1"/>
                         <constraint firstItem="67m-Gz-5nL" firstAttribute="leading" secondItem="4bW-nu-PyM" secondAttribute="leading" id="Bel-in-KSz"/>
+                        <constraint firstAttribute="trailing" secondItem="Mdu-me-PxK" secondAttribute="trailing" id="BpM-wG-hzL"/>
                         <constraint firstItem="zhE-sd-tpD" firstAttribute="top" secondItem="4bW-nu-PyM" secondAttribute="top" constant="30" id="Hv4-Ve-jOL"/>
                         <constraint firstItem="67m-Gz-5nL" firstAttribute="top" secondItem="Rkj-iL-29z" secondAttribute="bottom" constant="20" id="IfM-QN-mCX"/>
                         <constraint firstItem="kRM-oh-Ikv" firstAttribute="top" secondItem="8ga-Fs-LXn" secondAttribute="bottom" constant="20" id="JZl-Sw-ba7"/>
+                        <constraint firstItem="RnL-ig-JUl" firstAttribute="top" secondItem="YeC-xf-euf" secondAttribute="bottom" constant="20" id="JuM-yy-2oh"/>
                         <constraint firstAttribute="trailing" secondItem="RnL-ig-JUl" secondAttribute="trailing" constant="8" id="K9O-nf-HVU"/>
                         <constraint firstAttribute="trailing" secondItem="zhE-sd-tpD" secondAttribute="trailing" id="KJO-FX-BcG"/>
                         <constraint firstAttribute="trailing" secondItem="qgF-MF-lth" secondAttribute="trailing" id="Nku-7P-AuS"/>
                         <constraint firstItem="kRM-oh-Ikv" firstAttribute="leading" secondItem="4bW-nu-PyM" secondAttribute="leading" id="QCd-3s-847"/>
                         <constraint firstItem="QmN-5v-7sp" firstAttribute="top" secondItem="RnL-ig-JUl" secondAttribute="bottom" constant="20" id="QVn-WA-jFi"/>
-                        <constraint firstItem="RnL-ig-JUl" firstAttribute="top" secondItem="kRM-oh-Ikv" secondAttribute="bottom" constant="20" id="VBV-Lv-7ou"/>
                         <constraint firstItem="QmN-5v-7sp" firstAttribute="leading" secondItem="4bW-nu-PyM" secondAttribute="leading" constant="8" id="VoV-1B-OpJ"/>
+                        <constraint firstItem="Mdu-me-PxK" firstAttribute="width" secondItem="Mdu-me-PxK" secondAttribute="height" multiplier="4:1" id="XUt-G9-g6U"/>
+                        <constraint firstItem="Mdu-me-PxK" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="YeC-xf-euf" secondAttribute="trailing" constant="10" id="bp4-SL-LoR"/>
                         <constraint firstItem="zhE-sd-tpD" firstAttribute="centerX" secondItem="4bW-nu-PyM" secondAttribute="centerX" id="fNQ-hH-F3C"/>
                         <constraint firstItem="Rkj-iL-29z" firstAttribute="top" secondItem="4bW-nu-PyM" secondAttribute="top" constant="143" id="feD-Pq-LyO"/>
                         <constraint firstItem="jAR-mm-eeW" firstAttribute="top" secondItem="RnL-ig-JUl" secondAttribute="bottom" constant="20" id="fwj-51-VBf"/>
@@ -143,6 +160,7 @@
                         <constraint firstItem="hYw-3i-glO" firstAttribute="centerY" secondItem="67m-Gz-5nL" secondAttribute="centerY" id="jSx-Ri-rfC"/>
                         <constraint firstItem="LCw-QB-Mfv" firstAttribute="centerY" secondItem="8ga-Fs-LXn" secondAttribute="centerY" id="jdc-Zw-AGa"/>
                         <constraint firstItem="wIw-6s-vyh" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="kRM-oh-Ikv" secondAttribute="trailing" constant="10" id="m3a-kX-1JU"/>
+                        <constraint firstItem="YeC-xf-euf" firstAttribute="top" secondItem="kRM-oh-Ikv" secondAttribute="bottom" constant="20" id="sCM-Mh-coI"/>
                         <constraint firstItem="LCw-QB-Mfv" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="8ga-Fs-LXn" secondAttribute="trailing" constant="10" id="seb-Se-5eZ"/>
                         <constraint firstItem="zhE-sd-tpD" firstAttribute="leading" secondItem="4bW-nu-PyM" secondAttribute="leading" id="v7S-3u-r8j"/>
                         <constraint firstAttribute="bottom" secondItem="QmN-5v-7sp" secondAttribute="bottom" constant="85" id="vLk-pf-SXn"/>

--- a/LibraryComponents/Classes/Core/AndesCheckbox/AndesCheckbox.swift
+++ b/LibraryComponents/Classes/Core/AndesCheckbox/AndesCheckbox.swift
@@ -1,5 +1,5 @@
 //
-//  AndesCaheckbox.swift
+//  AndesCheckbox.swift
 //  AndesUI
 //
 //  Created by Rodrigo Pintos Costa on 6/15/20.
@@ -18,35 +18,35 @@ import UIKit
         }
     }
 
-    /// Sets the type of the AndesCaheckbox , default idle
+    /// Sets the type of the AndesCheckbox , default idle
    @objc public var type: AndesCheckboxType = .idle {
         didSet {
             self.updateContentView()
         }
     }
 
-    /// Sets the slign of the AndesCaheckbox , default left
+    /// Sets the slign of the AndesCheckbox , default left
     @objc public var align: AndesCheckboxAlign = .left {
         didSet {
             self.updateContentView()
         }
     }
 
-    /// Sets the status of the AndesCaheckbox , default unselected
+    /// Sets the status of the AndesCheckbox , default unselected
     @objc public var status: AndesCheckboxStatus = .unselected {
         didSet {
             self.updateContentView()
         }
     }
 
-    /// Sets the background color of the AndesCaheckbox , default white
+    /// Sets the background color of the AndesCheckbox , default white
     @objc public var buttonBackgroundColor: UIColor = .white {
         didSet {
             self.updateContentView()
         }
     }
 
-    /// Sets the selected background color of the AndesCaheckbox , default white
+    /// Sets the selected background color of the AndesCheckbox
     @objc public var selectedBackgroundColor: UIColor? {
         didSet {
             self.updateContentView()

--- a/LibraryComponents/Classes/Core/AndesCheckbox/AndesCheckbox.swift
+++ b/LibraryComponents/Classes/Core/AndesCheckbox/AndesCheckbox.swift
@@ -39,6 +39,20 @@ import UIKit
         }
     }
 
+    /// Sets the background color of the AndesCaheckbox , default white
+    @objc public var buttonBackgroundColor: UIColor = .white {
+        didSet {
+            self.updateContentView()
+        }
+    }
+
+    /// Sets the selected background color of the AndesCaheckbox , default white
+    @objc public var selectedBackgroundColor: UIColor? {
+        didSet {
+            self.updateContentView()
+        }
+    }
+
     /// Callback invoked when checkbox button is tapped
     internal var didTapped: ((AndesCheckbox) -> Void)?
 

--- a/LibraryComponents/Classes/Core/AndesCheckbox/Config/AndesCheckboxViewConfig.swift
+++ b/LibraryComponents/Classes/Core/AndesCheckbox/Config/AndesCheckboxViewConfig.swift
@@ -21,6 +21,7 @@ internal struct AndesCheckboxViewConfig {
     var borderSize: CGFloat?
     var type: AndesCheckboxTypeProtocol! = AndesCheckboxTypeIdle()
     var status: AndesCheckboxStatusProtocol! = AndesCheckboxStatusUnselected()
+    var buttonBackgroundColor: UIColor = .white
 
     init () { }
 
@@ -35,6 +36,17 @@ internal struct AndesCheckboxViewConfig {
         self.iconColor = self.type.iconColor
         self.borderColor = type.borderColor
         self.borderSize = type.borderSize
-        self.backgroundColor = type.backgroundColor
+        self.backgroundColor = getBackgroundColor(for: checkbox)
+        self.buttonBackgroundColor = checkbox.buttonBackgroundColor
+    }
+
+    private func getBackgroundColor(for checkbox: AndesCheckbox) -> UIColor {
+        guard let selectedBackgroundColor = checkbox.selectedBackgroundColor else { return type.backgroundColor }
+        switch checkbox.status {
+        case .selected:
+            return selectedBackgroundColor
+        default:
+            return type.backgroundColor
+        }
     }
 }

--- a/LibraryComponents/Classes/Core/AndesCheckbox/View/AndesCheckboxDefaultView.swift
+++ b/LibraryComponents/Classes/Core/AndesCheckbox/View/AndesCheckboxDefaultView.swift
@@ -83,6 +83,7 @@ class AndesCheckboxDefaultView: UIView, AndesCheckboxView {
     func updateView() {
         clearView()
         self.label.text = config.title
+        checkboxView.backgroundColor = config.buttonBackgroundColor
         updateBoxesViews()
         updateBoxesBorders()
         updateIcons()

--- a/LibraryComponents/Classes/Core/AndesRadioButton/AndesRadioButton.swift
+++ b/LibraryComponents/Classes/Core/AndesRadioButton/AndesRadioButton.swift
@@ -46,6 +46,13 @@ import UIKit
         }
     }
 
+    /// Sets the background color of the RadioButton , default white
+    @objc public var buttonBackgroundColor: UIColor = .white {
+        didSet {
+            self.updateContentView()
+        }
+    }
+
     /// Callback invoked when RadioButton  is tapped
     internal var didTapped: ((AndesRadioButton) -> Void)?
 

--- a/LibraryComponents/Classes/Core/AndesRadioButton/Config/AndesRadioButtonConfig.swift
+++ b/LibraryComponents/Classes/Core/AndesRadioButton/Config/AndesRadioButtonConfig.swift
@@ -16,6 +16,7 @@ internal struct AndesRadioButtonConfig {
     var type: AndesRadioButtonTypeProtocol! = AndesRadioButtonTypeIdle()
     var filled: Bool = false
     var titleNumberOfLines: Int?
+    var buttonBackgroundColor: UIColor = .white
 
     init () {
 
@@ -29,5 +30,6 @@ internal struct AndesRadioButtonConfig {
         self.tintColor = type.tintColor
         self.filled = radiobutton.status == .selected && radiobutton.type != .error
         self.titleNumberOfLines = radiobutton.titleNumberOfLines
+        self.buttonBackgroundColor = radiobutton.buttonBackgroundColor
     }
 }

--- a/LibraryComponents/Classes/Core/AndesRadioButton/View/AndesRadioButtonDefaultView.swift
+++ b/LibraryComponents/Classes/Core/AndesRadioButton/View/AndesRadioButtonDefaultView.swift
@@ -78,6 +78,7 @@ class AndesRadioButtonDefaultView: UIView, AndesRadioButtonView {
         self.radioButtonLabel.text = config.title
         self.radioButtonLabel.setAndesStyle(style: AndesStyleSheetManager.styleSheet.bodyM(color: config.textColor))
         self.radioButtonLabel.numberOfLines = config.titleNumberOfLines ?? 0
+        radioButtonView.backgroundColor = config.buttonBackgroundColor
         radioButtonLabel.lineBreakMode = .byTruncatingTail
         setupButtonView()
         updateRadioButtonsStyles()
@@ -95,6 +96,7 @@ class AndesRadioButtonDefaultView: UIView, AndesRadioButtonView {
             self.labelToLeftButtonConstraint.priority = .defaultHigh
             self.labelToLeadingConstraint.priority = .defaultLow
             self.leftRadioButton.filled = config.filled
+            self.leftRadioButton.backgroundColor = config.buttonBackgroundColor
 
             radiobuttonConstraint = NSLayoutConstraint(item: self.radioButtonLabel!, attribute: .leading, relatedBy: .equal, toItem: self.leftRadioButton!, attribute: .trailing, multiplier: 1, constant: 0)
         } else {
@@ -105,6 +107,7 @@ class AndesRadioButtonDefaultView: UIView, AndesRadioButtonView {
             self.labelToLeftButtonConstraint.priority = .defaultLow
             self.labelToLeadingConstraint.priority = .defaultHigh
             self.rightRadioButton.filled = config.filled
+            self.rightRadioButton.backgroundColor = config.buttonBackgroundColor
 
             radiobuttonConstraint = NSLayoutConstraint(item: self.rightRadioButton!, attribute: .leading, relatedBy: .equal, toItem: radioButtonLabel, attribute: .trailing, multiplier: 1, constant: 0)
         }


### PR DESCRIPTION
### Thanks for contributing to Andes UI!
## Description
- Added the possibility of choose background color for Andes Checkbox and Andes Radio Button
Try to answer these questions:
- What is it about?
Customize Andes Checkbox and Andes Radio Button
- How does it work?
You can specify the background color of the Andes Checkbox and Andes Radio Button
## Affected component
Is highly probable that this new code affects directly one (or more?) components inside this lib. Tell us who they are!
- Andes Radio Button
- Andes Checkbox
## RFC Link
If this change was discussed on RFC please paste link here.
## Screenshots / GIFs
This is a UI library, delight us with some stunning images.
- Before
![image](https://user-images.githubusercontent.com/49250268/106504130-4da56b00-64a5-11eb-8a79-c322d347f5d5.png)
- Now
![image](https://user-images.githubusercontent.com/49250268/106504180-5ac25a00-64a5-11eb-9bb7-6ca66c053ce3.png)
- TestApp
![Checkbox](https://user-images.githubusercontent.com/49250268/106521934-bac4fa80-64bd-11eb-9f12-94fbccf0c2c2.gif)
![RadioButton](https://user-images.githubusercontent.com/49250268/106521952-c0badb80-64bd-11eb-8ddb-9139b685e961.gif)

## Checks
Are you sure you followed all those steps? If so, repeat after me "I solemnly swear that ...":
   - [ ] I have coded an example inside the Demo App,
   - [ ] I have added proper tests,
   - [ ] I have modified the Changelog.md file,
   - [ ] I have updated GitHub wiki,
   - [ ] I have the explicit approval of one or more members of the UX Team,
   - [ ] I have checked that this code is ObjC compliant.
   - [ ] I have checked that all the new public enums conform to AndesEnumStringConvertible.
## Change type
This is easy, let us know what this code is about:
   - [ ] This code adds a new component
   - [ ] This code includes improvements to an existent component
   - [ ] This code improves or modifies ONLY the Demo App.
