### PR TITLE
Andes Radiobutton and Andes Checkbox with clear background.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Unpublished
+- Changed default background color to clear for Andes Checkbox and Andes Radio Button | Author: [@vveltri](https://github.com/vveltri)
 
 # v3.20.0
 ### 🚀 Features

--- a/Example/Tests/AndesCheckboxTest.swift
+++ b/Example/Tests/AndesCheckboxTest.swift
@@ -47,7 +47,7 @@ class AndesCheckboxTests: QuickSpec {
                 it("Has the idle view error, left view align, selected view status and background color + icon") {
                     let checkbox = AndesCheckbox(type: .idle, align: .left, status: .selected, title: "Checkbox")
 
-                    let selectedBackgroundColor = UIColor.Andes.blueML500
+                    let selectedBackgroundColor = AndesStyleSheetManager.styleSheet.accentColor
 
                     let configuration = AndesCheckboxViewConfig.init(for: checkbox)
 

--- a/LibraryComponents/Classes/Core/AndesCheckbox/Status/AndesCheckboxStatusSelected.swift
+++ b/LibraryComponents/Classes/Core/AndesCheckbox/Status/AndesCheckboxStatusSelected.swift
@@ -9,5 +9,5 @@ import Foundation
 // Handle checkbox status selected
 class AndesCheckboxStatusSelected: AndesCheckboxStatusProtocol {
     var icon: String? = AndesIcons.checkboxSelected16
-    var backgroundColor: UIColor = UIColor.Andes.blueML500
+    var backgroundColor: UIColor = AndesStyleSheetManager.styleSheet.accentColor
 }

--- a/LibraryComponents/Classes/Core/AndesCheckbox/View/Default/AndesCheckboxDefaultView.xib
+++ b/LibraryComponents/Classes/Core/AndesCheckbox/View/Default/AndesCheckboxDefaultView.xib
@@ -54,7 +54,7 @@
                     </connections>
                 </button>
             </subviews>
-            <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
             <constraints>
                 <constraint firstAttribute="trailing" secondItem="tab-mw-4wG" secondAttribute="trailing" id="7oL-SF-lhq"/>
                 <constraint firstItem="vNJ-co-emm" firstAttribute="leading" secondItem="dhw-ue-pA7" secondAttribute="trailing" priority="750" constant="12" id="8DS-id-H6m"/>

--- a/LibraryComponents/Classes/Core/AndesRadioButton/View/AndesRadioButtonDefaultView.xib
+++ b/LibraryComponents/Classes/Core/AndesRadioButton/View/AndesRadioButtonDefaultView.xib
@@ -3,8 +3,7 @@
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17126"/>
-        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17125"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -33,7 +32,7 @@
                 </label>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="tMQ-xe-WWY" customClass="AndesRadioButtonControl" customModule="AndesUI">
                     <rect key="frame" x="4" y="6" width="32" height="32"/>
-                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="32" id="DZq-eE-jax"/>
                         <constraint firstAttribute="height" constant="32" id="aj5-H1-qiM"/>
@@ -42,7 +41,7 @@
                 </view>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="UBx-hG-Q69" customClass="AndesRadioButtonControl" customModule="AndesUI">
                     <rect key="frame" x="144" y="6" width="32" height="32"/>
-                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="32" id="94b-Xg-F6T"/>
                         <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="32" id="C1K-vJ-jZ4"/>
@@ -50,7 +49,7 @@
                     </constraints>
                 </view>
             </subviews>
-            <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
             <constraints>
                 <constraint firstItem="UBx-hG-Q69" firstAttribute="leading" secondItem="1Wf-Ci-oc3" secondAttribute="trailing" priority="750" constant="4" id="4EE-Lz-XmI"/>
                 <constraint firstItem="tMQ-xe-WWY" firstAttribute="leading" secondItem="d18-F7-uIb" secondAttribute="leading" constant="4" id="E7V-gY-uPh"/>
@@ -67,9 +66,4 @@
             <point key="canvasLocation" x="-36.231884057971016" y="-244.41964285714283"/>
         </view>
     </objects>
-    <resources>
-        <systemColor name="systemBackgroundColor">
-            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-        </systemColor>
-    </resources>
 </document>


### PR DESCRIPTION
### Thanks for contributing to Andes UI!
## Description
- Clear background color for Andes Checkbox and Andes Radio Button
Try to answer these questions:
- What is it about?
Fixed Andes Checkbox and Andes Radio button background color setting clear color as default background color.
- How does it work?
You can specify the background color of the Andes Checkbox and Andes Radio Button
## Affected component
Is highly probable that this new code affects directly one (or more?) components inside this lib. Tell us who they are!
- Andes Radio Button
- Andes Checkbox
## RFC Link
If this change was discussed on RFC please paste link here.
## Screenshots / GIFs
This is a UI library, delight us with some stunning images.
- Before
![image](https://user-images.githubusercontent.com/49250268/106504130-4da56b00-64a5-11eb-8a79-c322d347f5d5.png)
- Now
![image](https://user-images.githubusercontent.com/49250268/106504180-5ac25a00-64a5-11eb-9bb7-6ca66c053ce3.png)

## Checks
Are you sure you followed all those steps? If so, repeat after me "I solemnly swear that ...":
   - [ ] I have coded an example inside the Demo App,
   - [ ] I have added proper tests,
   - [ ] I have modified the Changelog.md file,
   - [ ] I have updated GitHub wiki,
   - [ ] I have the explicit approval of one or more members of the UX Team,
   - [ ] I have checked that this code is ObjC compliant.
   - [ ] I have checked that all the new public enums conform to AndesEnumStringConvertible.
## Change type
This is easy, let us know what this code is about:
   - [ ] This code adds a new component
   - [ ] This code includes improvements to an existent component
   - [ ] This code improves or modifies ONLY the Demo App.
