### PR TITLE
warning state and attribute text added

### DIFF
--- a/Example/AndesUI/TextFields/Views/TextAreaViewController.swift
+++ b/Example/AndesUI/TextFields/Views/TextAreaViewController.swift
@@ -19,7 +19,8 @@ class TextAreaViewController: UIViewController {
     @IBOutlet weak var counterField: UITextField!
     @IBOutlet weak var configView: UIView!
     @IBOutlet weak var updateButton: AndesButton!
-
+    @IBOutlet weak var boldAttributeText: UITextField!
+    
     var statePicker: UIPickerView = UIPickerView()
     var typePicker: UIPickerView = UIPickerView()
     var state: AndesTextInputState = .idle
@@ -47,7 +48,6 @@ class TextAreaViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        setupButtons()
         createPickerViews()
         createTextViews()
         setupUI()
@@ -57,11 +57,7 @@ class TextAreaViewController: UIViewController {
         configView.isHidden = true
         textField.delegate = self
     }
-
-    fileprivate func setupButtons() {
-
-    }
-
+    
     func createPickerViews() {
         stateTField.inputView = statePicker
         statePicker.delegate = self
@@ -71,14 +67,25 @@ class TextAreaViewController: UIViewController {
     func createTextViews() {
         counterField.delegate = self
     }
-
+    
+    func attributedText(withString string: String, boldString: String) -> NSAttributedString {
+        let attributedString = NSMutableAttributedString(string: string,
+                                                         attributes: [NSAttributedString.Key.font: AndesStyleSheetManager.styleSheet.regularSystemFont(size: 14)])
+        let boldFontAttribute: [NSAttributedString.Key: Any] = [NSAttributedString.Key.font: AndesStyleSheetManager.styleSheet.semiboldSystemFontOfSize(size: 14)]
+        let range = (string as NSString).range(of: boldString)
+        attributedString.addAttributes(boldFontAttribute, range: range)
+        return attributedString
+    }
+    
     @IBAction func updateBtnTapped(_ sender: Any) {
         let counter: UInt16 = UInt16(counterField.text!) ?? 0
-           textField.counter = counter
+        textField.counter = counter
            textField.label = self.labelField.text
            textField.placeholder = self.placeholderField.text
            textField.helper = self.helperField.text
            textField.state = self.state
+           textField.attributeText = attributedText(withString: self.textField.text ,
+                                                 boldString: boldAttributeText.text ?? "")
     }
 
     @IBAction func toggleConfigTapped(_ sender: Any) {
@@ -111,7 +118,7 @@ extension TextAreaViewController: UIPickerViewDelegate {
 extension TextAreaViewController: UIPickerViewDataSource {
     func pickerView(_ pickerView: UIPickerView, numberOfRowsInComponent component: Int) -> Int {
         if pickerView == statePicker {
-            return 4
+            return AndesTextInputState.allCases.count
         }
         if pickerView == typePicker {
             return 2

--- a/Example/AndesUI/TextFields/Views/TextAreaViewController.swift
+++ b/Example/AndesUI/TextFields/Views/TextAreaViewController.swift
@@ -69,8 +69,9 @@ class TextAreaViewController: UIViewController {
     }
     
     func attributedText(withString string: String, boldString: String) -> NSAttributedString {
+        let attributes = [NSAttributedString.Key.font: AndesStyleSheetManager.styleSheet.regularSystemFont(size: 14)]
         let attributedString = NSMutableAttributedString(string: string,
-                                                         attributes: [NSAttributedString.Key.font: AndesStyleSheetManager.styleSheet.regularSystemFont(size: 14)])
+                                                         attributes: attributes)
         let boldFontAttribute: [NSAttributedString.Key: Any] = [NSAttributedString.Key.font: AndesStyleSheetManager.styleSheet.semiboldSystemFontOfSize(size: 14)]
         let range = (string as NSString).range(of: boldString)
         attributedString.addAttributes(boldFontAttribute, range: range)
@@ -80,11 +81,11 @@ class TextAreaViewController: UIViewController {
     @IBAction func updateBtnTapped(_ sender: Any) {
         let counter: UInt16 = UInt16(counterField.text!) ?? 0
         textField.counter = counter
-           textField.label = self.labelField.text
-           textField.placeholder = self.placeholderField.text
-           textField.helper = self.helperField.text
-           textField.state = self.state
-           textField.attributeText = attributedText(withString: self.textField.text ,
+        textField.label = self.labelField.text
+        textField.placeholder = self.placeholderField.text
+        textField.helper = self.helperField.text
+        textField.state = self.state
+        textField.attributeText = attributedText(withString: self.textField.text ,
                                                  boldString: boldAttributeText.text ?? "")
     }
 

--- a/Example/AndesUI/TextFields/Views/TextAreaViewController.xib
+++ b/Example/AndesUI/TextFields/Views/TextAreaViewController.xib
@@ -1,15 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16096" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16086"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17125"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="TextAreaViewController" customModule="AndesUI_DemoApp" customModuleProvider="target">
             <connections>
+                <outlet property="boldAttributeText" destination="gM8-65-Ia0" id="gWf-Ce-yZH"/>
                 <outlet property="configToggleButton" destination="j81-dG-snK" id="Fo4-49-6ds"/>
                 <outlet property="configView" destination="e2j-V6-a2F" id="ycc-rl-Y3p"/>
                 <outlet property="counterField" destination="g9Q-CH-OUi" id="fNo-3l-xxs"/>
@@ -31,11 +33,11 @@
                     <rect key="frame" x="0.0" y="44" width="414" height="818"/>
                     <subviews>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="uvK-LY-Ca1">
-                            <rect key="frame" x="0.0" y="0.0" width="414" height="438"/>
+                            <rect key="frame" x="0.0" y="0.0" width="414" height="487"/>
                             <subviews>
                                 <view contentMode="scaleToFill" placeholderIntrinsicWidth="362" placeholderIntrinsicHeight="50" translatesAutoresizingMaskIntoConstraints="NO" id="lLN-fr-g2R" customClass="AndesTextArea" customModule="AndesUI">
                                     <rect key="frame" x="10" y="20" width="394" height="50"/>
-                                    <color key="backgroundColor" systemColor="linkColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                    <color key="backgroundColor" systemColor="linkColor"/>
                                     <userDefinedRuntimeAttributes>
                                         <userDefinedRuntimeAttribute type="string" keyPath="ibState" value="Idle"/>
                                         <userDefinedRuntimeAttribute type="number" keyPath="counter">
@@ -65,10 +67,10 @@ sed autem. Error quasi provident ut vitae</string>
                                     </connections>
                                 </view>
                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="e2j-V6-a2F" userLabel="Config View">
-                                    <rect key="frame" x="16" y="138" width="382" height="285"/>
+                                    <rect key="frame" x="16" y="138" width="382" height="334"/>
                                     <subviews>
                                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="15" translatesAutoresizingMaskIntoConstraints="NO" id="JwQ-yl-2pK">
-                                            <rect key="frame" x="0.0" y="0.0" width="382" height="285"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="382" height="334"/>
                                             <subviews>
                                                 <stackView opaque="NO" contentMode="scaleToFill" spacing="35" translatesAutoresizingMaskIntoConstraints="NO" id="Y4R-YK-DS6">
                                                     <rect key="frame" x="0.0" y="0.0" width="382" height="34"/>
@@ -157,8 +159,24 @@ sed autem. Error quasi provident ut vitae</string>
                                                         </textField>
                                                     </subviews>
                                                 </stackView>
+                                                <stackView opaque="NO" contentMode="scaleToFill" spacing="35" translatesAutoresizingMaskIntoConstraints="NO" id="gl9-bL-iFr">
+                                                    <rect key="frame" x="0.0" y="245" width="382" height="34"/>
+                                                    <subviews>
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Bold Word" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xH6-yB-nDS">
+                                                            <rect key="frame" x="0.0" y="0.0" width="157" height="34"/>
+                                                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                            <nil key="textColor"/>
+                                                            <nil key="highlightedColor"/>
+                                                        </label>
+                                                        <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="maxime" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="gM8-65-Ia0">
+                                                            <rect key="frame" x="192" y="0.0" width="190" height="34"/>
+                                                            <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                            <textInputTraits key="textInputTraits"/>
+                                                        </textField>
+                                                    </subviews>
+                                                </stackView>
                                                 <view contentMode="scaleToFill" placeholderIntrinsicWidth="48" placeholderIntrinsicHeight="40" translatesAutoresizingMaskIntoConstraints="NO" id="csX-wA-w3d" customClass="AndesButton" customModule="AndesUI">
-                                                    <rect key="frame" x="0.0" y="245" width="382" height="40"/>
+                                                    <rect key="frame" x="0.0" y="294" width="382" height="40"/>
                                                     <color key="backgroundColor" red="0.20392156859999999" green="0.78039215689999997" blue="0.34901960780000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <userDefinedRuntimeAttributes>
                                                         <userDefinedRuntimeAttribute type="string" keyPath="ibHierarchy" value="LOUD"/>
@@ -172,21 +190,22 @@ sed autem. Error quasi provident ut vitae</string>
                                             <constraints>
                                                 <constraint firstItem="y9b-1s-2Y8" firstAttribute="width" secondItem="lJu-Uz-R7H" secondAttribute="width" id="0yS-9G-ObY"/>
                                                 <constraint firstItem="g9Q-CH-OUi" firstAttribute="width" secondItem="lJu-Uz-R7H" secondAttribute="width" id="BjH-bh-Gqx"/>
+                                                <constraint firstItem="gM8-65-Ia0" firstAttribute="width" secondItem="g9Q-CH-OUi" secondAttribute="width" id="DFR-p9-bCT"/>
                                                 <constraint firstItem="fqa-lD-e55" firstAttribute="width" secondItem="lJu-Uz-R7H" secondAttribute="width" id="H0s-CY-z5c"/>
                                             </constraints>
                                         </stackView>
                                     </subviews>
-                                    <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                    <viewLayoutGuide key="safeArea" id="MLQ-HS-hes"/>
+                                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                     <constraints>
                                         <constraint firstItem="JwQ-yl-2pK" firstAttribute="leading" secondItem="e2j-V6-a2F" secondAttribute="leading" id="2IC-aM-3WP"/>
                                         <constraint firstAttribute="bottom" secondItem="JwQ-yl-2pK" secondAttribute="bottom" id="59M-bo-nDZ"/>
                                         <constraint firstItem="JwQ-yl-2pK" firstAttribute="top" secondItem="MLQ-HS-hes" secondAttribute="top" id="bWT-FF-a1S"/>
                                         <constraint firstAttribute="trailing" secondItem="JwQ-yl-2pK" secondAttribute="trailing" id="gfj-LS-cwl"/>
                                     </constraints>
-                                    <viewLayoutGuide key="safeArea" id="MLQ-HS-hes"/>
                                 </view>
                             </subviews>
-                            <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                             <constraints>
                                 <constraint firstItem="e2j-V6-a2F" firstAttribute="top" secondItem="j81-dG-snK" secondAttribute="bottom" constant="8" symbolic="YES" id="CM9-9y-51b"/>
                                 <constraint firstItem="j81-dG-snK" firstAttribute="top" secondItem="lLN-fr-g2R" secondAttribute="bottom" constant="20" id="DKG-k1-hYv"/>
@@ -211,15 +230,23 @@ sed autem. Error quasi provident ut vitae</string>
                     </constraints>
                 </scrollView>
             </subviews>
-            <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+            <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
+            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
             <constraints>
                 <constraint firstItem="vUN-kp-3ea" firstAttribute="top" secondItem="6lo-Kj-3jr" secondAttribute="top" id="Fth-ht-tMx"/>
                 <constraint firstItem="vUN-kp-3ea" firstAttribute="leading" secondItem="6lo-Kj-3jr" secondAttribute="leading" id="gou-qd-rgb"/>
                 <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="6lo-Kj-3jr" secondAttribute="trailing" id="kch-Dc-5tU"/>
                 <constraint firstItem="vUN-kp-3ea" firstAttribute="bottom" secondItem="6lo-Kj-3jr" secondAttribute="bottom" id="wFG-R8-AtI"/>
             </constraints>
-            <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
             <point key="canvasLocation" x="36" y="35"/>
         </view>
     </objects>
+    <resources>
+        <systemColor name="linkColor">
+            <color red="0.0" green="0.47843137254901963" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
 </document>

--- a/Example/AndesUI/TextFields/Views/TextFieldViewController.swift
+++ b/Example/AndesUI/TextFields/Views/TextFieldViewController.swift
@@ -53,7 +53,8 @@ class TextFieldViewController: UIViewController {
             "CHECK": { [weak self] in self?.textField.rightContent = AndesTextFieldComponentCheck() },
             "CHEC": { [weak self] in self?.textField.rightContent = AndesTextFieldComponentClear() },
             "ERROR": { [weak self] in self?.textField.state = .error },
-            "ERRO": { [weak self] in self?.textField.state = .idle }
+            "ERRO": { [weak self] in self?.textField.state = .idle },
+            "WARNIN": { [weak self] in self?.textField.state = .warning }
         ]
     }
 
@@ -148,7 +149,7 @@ extension TextFieldViewController: UIPickerViewDelegate {
 extension TextFieldViewController: UIPickerViewDataSource {
     func pickerView(_ pickerView: UIPickerView, numberOfRowsInComponent component: Int) -> Int {
         if pickerView == statePicker {
-            return 4
+            return AndesTextInputState.allCases.count
         }
         if pickerView == leftCompPicker {
             return leftComponents.count

--- a/Example/AndesUI/TextFields/Views/TextFieldViewController.swift
+++ b/Example/AndesUI/TextFields/Views/TextFieldViewController.swift
@@ -54,7 +54,8 @@ class TextFieldViewController: UIViewController {
             "CHEC": { [weak self] in self?.textField.rightContent = AndesTextFieldComponentClear() },
             "ERROR": { [weak self] in self?.textField.state = .error },
             "ERRO": { [weak self] in self?.textField.state = .idle },
-            "WARNIN": { [weak self] in self?.textField.state = .warning }
+            "WARNIN": { [weak self] in self?.textField.state = .warning },
+            "WARNINING": { [weak self] in self?.textField.state = .warning }
         ]
     }
 

--- a/Example/AndesUI/TextFields/Views/TextFieldViewController.xib
+++ b/Example/AndesUI/TextFields/Views/TextFieldViewController.xib
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16097.3" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17125"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -38,7 +39,7 @@
                             <subviews>
                                 <view contentMode="scaleToFill" placeholderIntrinsicWidth="362" placeholderIntrinsicHeight="50" translatesAutoresizingMaskIntoConstraints="NO" id="9EC-n8-a4i" customClass="AndesTextField" customModule="AndesUI">
                                     <rect key="frame" x="10" y="20" width="362" height="50"/>
-                                    <color key="backgroundColor" systemColor="linkColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                    <color key="backgroundColor" systemColor="linkColor"/>
                                     <accessibility key="accessibilityConfiguration" identifier="mainTextField"/>
                                     <userDefinedRuntimeAttributes>
                                         <userDefinedRuntimeAttribute type="string" keyPath="ibState" value="Idle"/>
@@ -210,17 +211,17 @@
                                             </constraints>
                                         </stackView>
                                     </subviews>
-                                    <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                    <viewLayoutGuide key="safeArea" id="cMm-AJ-7T2"/>
+                                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                     <constraints>
                                         <constraint firstAttribute="trailing" secondItem="w8d-2Y-yYt" secondAttribute="trailing" id="03m-js-Ocp"/>
                                         <constraint firstAttribute="bottom" secondItem="w8d-2Y-yYt" secondAttribute="bottom" id="5d9-D9-iTm"/>
                                         <constraint firstItem="w8d-2Y-yYt" firstAttribute="top" secondItem="cMm-AJ-7T2" secondAttribute="top" id="Dxd-gN-K1m"/>
                                         <constraint firstItem="w8d-2Y-yYt" firstAttribute="leading" secondItem="L6o-fs-Hr6" secondAttribute="leading" id="qYA-bq-nZF"/>
                                     </constraints>
-                                    <viewLayoutGuide key="safeArea" id="cMm-AJ-7T2"/>
                                 </view>
                             </subviews>
-                            <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                             <constraints>
                                 <constraint firstItem="9EC-n8-a4i" firstAttribute="leading" secondItem="fN9-qH-Zz7" secondAttribute="leading" constant="10" id="1PL-PH-02v"/>
                                 <constraint firstAttribute="trailing" secondItem="9EC-n8-a4i" secondAttribute="trailing" constant="10" id="9FE-KB-q8B"/>
@@ -245,6 +246,7 @@
                     </constraints>
                 </scrollView>
             </subviews>
+            <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
             <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
             <constraints>
                 <constraint firstItem="vUN-kp-3ea" firstAttribute="bottom" secondItem="22t-hI-w3L" secondAttribute="bottom" id="cpv-ku-ShV"/>
@@ -253,8 +255,15 @@
                 <constraint firstItem="22t-hI-w3L" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" id="w5z-uf-XpR"/>
             </constraints>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
-            <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
             <point key="canvasLocation" x="114.49275362318842" y="114.84375"/>
         </view>
     </objects>
+    <resources>
+        <systemColor name="linkColor">
+            <color red="0.0" green="0.47843137254901963" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
 </document>

--- a/Example/Tests/AndesStyleSheetTests.swift
+++ b/Example/Tests/AndesStyleSheetTests.swift
@@ -146,6 +146,10 @@ class AndesStyleSheetWhiteMock: AndesStyleSheet {
     var feedbackColorCaution: UIColor = .white
 
     var feedbackColorPositive: UIColor = .white
+    
+    var feedbackColorWarning: UIColor = .white
+    
+    var textColorWarning: UIColor = .white
 
     func titleXS(color: UIColor) -> AndesFontStyle {
         return mockAndesFontStyle
@@ -203,6 +207,10 @@ class AndesStyleSheetWhiteMock: AndesStyleSheet {
 }
 
 class AndesStyleSheetBlackMock: AndesStyleSheet {
+    var textColorWarning: UIColor = .black
+    
+    var feedbackColorWarning: UIColor = .black
+    
     var bgColorPrimary: UIColor = .black
 
     var bgColorSecondary: UIColor = .black

--- a/LibraryComponents/Classes/Core/AndesTextField/AndesTextArea.swift
+++ b/LibraryComponents/Classes/Core/AndesTextField/AndesTextArea.swift
@@ -12,6 +12,13 @@ import UIKit
 @objc public class AndesTextArea: UIView {
     internal var contentView: AndesTextFieldView!
 
+    /// Attribute for textfield
+    @objc public var attributeText: NSAttributedString? {
+        didSet {
+            contentView.attributeText = attributeText
+        }
+    }
+    
     /// The state of an AndesTextfield defines its behaviours an colours.
     @objc public var state: AndesTextInputState = .idle {
         didSet {

--- a/LibraryComponents/Classes/Core/AndesTextField/AndesTextField.swift
+++ b/LibraryComponents/Classes/Core/AndesTextField/AndesTextField.swift
@@ -9,7 +9,7 @@ import UIKit
 
 @objc public class AndesTextField: UIView {
     internal var contentView: AndesTextFieldView!
-
+    
     /// The state of an AndesTextfield defines its behaviours an colours.
     @objc public var state: AndesTextInputState = .idle {
         didSet {
@@ -75,6 +75,12 @@ import UIKit
         set { contentView.text = newValue }
     }
 
+    @objc public var attributeText: NSAttributedString? {
+        didSet {
+            contentView.attributeText = attributeText
+        }
+    }
+    
     @objc public weak var delegate: AndesTextFieldDelegate?
 
     internal private(set) var inputTraits: UITextInputTraits? {

--- a/LibraryComponents/Classes/Core/AndesTextField/State/AndesTextFieldStateFactory.swift
+++ b/LibraryComponents/Classes/Core/AndesTextField/State/AndesTextFieldStateFactory.swift
@@ -18,6 +18,8 @@ internal class AndesTextFieldStateFactory {
             return AndesTextFieldStateDisabled()
         case .readOnly:
             return AndesTextFieldStateReadonly()
+        case .warning:
+            return AndesTextFieldStateWarning(focuesd: isEditing)
         }
     }
 }

--- a/LibraryComponents/Classes/Core/AndesTextField/State/AndesTextFieldStateWarning.swift
+++ b/LibraryComponents/Classes/Core/AndesTextField/State/AndesTextFieldStateWarning.swift
@@ -1,0 +1,33 @@
+//
+//  AndesTextFieldStateWarning.swift
+//  AndesUI
+//
+//  Created by Oscar Sierra Zuniga on 2/02/21.
+//
+
+import Foundation
+struct AndesTextFieldStateWarning: AndesTextFieldStateProtocol {
+    var borderColor = AndesStyleSheetManager.styleSheet.feedbackColorWarning
+    var borderWidth: CGFloat = 1
+    var borderDashed: Bool = false
+
+    var labelTextColor = AndesStyleSheetManager.styleSheet.textColorWarning
+
+    var helperColor = AndesStyleSheetManager.styleSheet.textColorWarning
+    var helperIconTintColor: UIColor? = AndesStyleSheetManager.styleSheet.textColorWhite
+    var helperIconName: String? = "andes_ui_feedback_error_16"
+    var helperSemibold: Bool = true
+
+    var backgroundColor = AndesStyleSheetManager.styleSheet.bgColorWhite
+    var inputTextColor = AndesStyleSheetManager.styleSheet.textColorPrimary
+    var editingEnabled = true
+
+    var placeholderTextColor = AndesStyleSheetManager.styleSheet.textColorSecondary
+
+    init(focuesd: Bool) {
+        if focuesd {
+            backgroundColor = AndesStyleSheetManager.styleSheet.bgColorWhite
+            borderWidth = 2
+        }
+    }
+}

--- a/LibraryComponents/Classes/Core/AndesTextField/State/AndesTextInputState.swift
+++ b/LibraryComponents/Classes/Core/AndesTextField/State/AndesTextInputState.swift
@@ -13,13 +13,15 @@ import Foundation
     case error
     case disabled
     case readOnly
-
+    case warning
+    
     public static func keyFor(_ value: AndesTextInputState) -> String {
         switch value {
         case .idle: return "IDLE"
         case .error: return "ERROR"
         case .readOnly: return "READONLY"
         case .disabled: return "DISABLED"
+        case .warning: return "WARNING"
         }
     }
 

--- a/LibraryComponents/Classes/Core/AndesTextField/View/AndesTextFieldAbstractView.swift
+++ b/LibraryComponents/Classes/Core/AndesTextField/View/AndesTextFieldAbstractView.swift
@@ -19,6 +19,7 @@ class AndesTextFieldAbstractView: UIView, AndesTextFieldView {
 
     var borderLayer: CAShapeLayer?
     var text: String = ""
+    var attributeText: NSAttributedString?
     var customInputView: UIView?
     var customInputAccessoryView: UIView?
     weak var delegate: AndesTextFieldViewDelegate?

--- a/LibraryComponents/Classes/Core/AndesTextField/View/AndesTextFieldView.swift
+++ b/LibraryComponents/Classes/Core/AndesTextField/View/AndesTextFieldView.swift
@@ -12,6 +12,7 @@ internal protocol AndesTextFieldView: UIView {
     var delegate: AndesTextFieldViewDelegate? { get set }
 
     var text: String { get set } // input text
+    var attributeText: NSAttributedString? { get set }
     var config: AndesTextFieldViewConfig { get }
     var customInputView: UIView? {get set}
     var customInputAccessoryView: UIView? { get set }

--- a/LibraryComponents/Classes/Core/AndesTextField/View/Default/AndesTextFieldDefaultView.swift
+++ b/LibraryComponents/Classes/Core/AndesTextField/View/Default/AndesTextFieldDefaultView.swift
@@ -22,6 +22,12 @@ class AndesTextFieldDefaultView: AndesTextFieldAbstractView {
             textChanged(self.textField)
         }
     }
+    
+    override var attributeText: NSAttributedString? {
+        didSet {
+            textField.attributedText = attributeText
+        }
+    }
 
     override var customInputView: UIView? {
         get {

--- a/LibraryComponents/Classes/Core/AndesTextField/View/TextArea/AndesTextAreaView.swift
+++ b/LibraryComponents/Classes/Core/AndesTextField/View/TextArea/AndesTextAreaView.swift
@@ -21,6 +21,12 @@ class AndesTextAreaView: AndesTextFieldAbstractView {
         }
     }
 
+    override var attributeText: NSAttributedString? {
+        didSet {
+            textView.attributedText = attributeText
+        }
+    }
+    
     override var customInputView: UIView? {
         get {
             return textView.inputView

--- a/LibraryComponents/Classes/Core/Stylesheet/AndesColorStrategyiOS10.swift
+++ b/LibraryComponents/Classes/Core/Stylesheet/AndesColorStrategyiOS10.swift
@@ -34,8 +34,10 @@ public class AndesColorStrategyiOS10: AndesColors {
     public var textColorPositive: UIColor = UIColor.Andes.green500
     public var tetColorLink: UIColor = UIColor.Andes.blueMP500
     public var textColorWhite: UIColor = UIColor.Andes.white
+    public var textColorWarning: UIColor = UIColor.Andes.orange500
 
     public var feedbackColorCaution: UIColor = UIColor.Andes.orange500
     public var feedbackColorNegative: UIColor = UIColor.Andes.red500
     public var feedbackColorPositive: UIColor = UIColor.Andes.green500
+    public var feedbackColorWarning: UIColor = UIColor.Andes.orange500
 }

--- a/LibraryComponents/Classes/Core/Stylesheet/AndesColorStrategyiOS11.swift
+++ b/LibraryComponents/Classes/Core/Stylesheet/AndesColorStrategyiOS11.swift
@@ -34,9 +34,11 @@ public class AndesColorStrategyiOS11: AndesColors {
     public var textColorPositive: UIColor = UIColor(named: "andes-text-color-positive", in: AndesBundle.bundle(), compatibleWith: nil)!
     public var tetColorLink: UIColor = UIColor(named: "andes-text-color-link", in: AndesBundle.bundle(), compatibleWith: nil)!
     public var textColorWhite: UIColor = UIColor(named: "andes-text-color-white", in: AndesBundle.bundle(), compatibleWith: nil)!
+    public var textColorWarning: UIColor = UIColor(named: "andes-text-color-warning", in: AndesBundle.bundle(), compatibleWith: nil)!
 
     public var feedbackColorNegative: UIColor = UIColor(named: "andes-feedback-color-negative", in: AndesBundle.bundle(), compatibleWith: nil)!
     public var feedbackColorPositive: UIColor = UIColor(named: "andes-feedback-color-positive", in: AndesBundle.bundle(), compatibleWith: nil)!
     public var feedbackColorCaution: UIColor = UIColor(named: "andes-feedback-color-caution", in: AndesBundle.bundle(), compatibleWith: nil)!
+    public var feedbackColorWarning: UIColor = UIColor(named: "andes-feedback-color-warning", in: AndesBundle.bundle(), compatibleWith: nil)!
 
 }

--- a/LibraryComponents/Classes/Core/Stylesheet/AndesStyleSheet.swift
+++ b/LibraryComponents/Classes/Core/Stylesheet/AndesStyleSheet.swift
@@ -44,10 +44,12 @@ import Foundation
     var textColorPositive: UIColor { get }
     var tetColorLink: UIColor { get }
     var textColorWhite: UIColor { get }
+    var textColorWarning: UIColor { get }
 
     var feedbackColorNegative: UIColor { get }
     var feedbackColorCaution: UIColor { get }
     var feedbackColorPositive: UIColor { get }
+    var feedbackColorWarning: UIColor { get }
 }
 
 /**

--- a/LibraryComponents/Classes/Core/Stylesheet/AndesStyleSheetDefault.swift
+++ b/LibraryComponents/Classes/Core/Stylesheet/AndesStyleSheetDefault.swift
@@ -36,10 +36,12 @@ import Foundation
     public lazy var textColorPositive: UIColor = self.stylesheetStrategy.textColorPositive
     public lazy var tetColorLink: UIColor = self.stylesheetStrategy.tetColorLink
     public lazy var textColorWhite: UIColor = self.stylesheetStrategy.textColorWhite
+    public lazy var textColorWarning: UIColor = self.stylesheetStrategy.textColorWarning
 
     public lazy var feedbackColorCaution: UIColor = self.stylesheetStrategy.feedbackColorCaution
     public lazy var feedbackColorPositive: UIColor = self.stylesheetStrategy.feedbackColorPositive
     public lazy var feedbackColorNegative: UIColor = self.stylesheetStrategy.feedbackColorNegative
+    public lazy var feedbackColorWarning: UIColor = self.stylesheetStrategy.feedbackColorWarning
 
     public override init() {
         //TODO: Remove when iOS 11 is minimum deployment target, use ios 11 strat when new build system issues are solved


### PR DESCRIPTION
### Thanks for contributing to Andes UI!
## Description
Describe why we need these changes in the lib.
Try to answer these questions:
- What is it about?
Nuevo estado en el componente AndesTextField y AndesTextArea

tambien se agrega la opción de pasarle un `attributeString` a AndesTextField y AndesTextArea.
- How does it work?
textField.state = .warning
textArea.state = .warning
## Affected component
Is highly probable that this new code affects directly one (or more?) components inside this lib. Tell us who they are!
## RFC Link
[RFC](https://docs.google.com/document/d/1yXMHOsXp7nyRMVnq1A3GuuPYaNLqL0VU2-oQuKeW1_o/edit)
## Screenshots / GIFs
![Simulator Screen Shot - iPod touch (7th generation) - 2021-02-04 at 11 38 43](https://user-images.githubusercontent.com/69980125/106925881-7ebcb000-66de-11eb-8995-1593f0afd889.png)
![Simulator Screen Shot - iPod touch (7th generation) - 2021-02-04 at 11 38 56](https://user-images.githubusercontent.com/69980125/106925891-81b7a080-66de-11eb-8791-064fc899da2f.png)

## Checks
Are you sure you followed all those steps? If so, repeat after me "I solemnly swear that ...":
   - [x] I have coded an example inside the Demo App,
   - [ ] I have added proper tests,
   - [ ] I have modified the Changelog.md file,
   - [ ] I have updated GitHub wiki,
   - [ ] I have the explicit approval of one or more members of the UX Team,
   - [ ] I have checked that this code is ObjC compliant.
   - [ ] I have checked that all the new public enums conform to AndesEnumStringConvertible.
## Change type
This is easy, let us know what this code is about:
   - [ ] This code adds a new component
   - [x] This code includes improvements to an existent component
   - [ ] This code improves or modifies ONLY the Demo App.
