### PR TITLE
Add warning colorset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 3.21.1 Unpublished
+### 🚀 Features
+- Added warning colorset | Authors [joalonspint](https://github.com/joalonsopint)
+
 # 3.21.0
 ### 🚀 Features
 - Added icons to LocalIcons | Authors: [@amacagno](https://github.com/amacagno)

--- a/LibraryComponents/Resources/Core/Assets/AndesPaletteColors.xcassets/andes-feedback-color-warning.colorset/Contents.json
+++ b/LibraryComponents/Resources/Core/Assets/AndesPaletteColors.xcassets/andes-feedback-color-warning.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.200",
+          "green" : "0.467",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/LibraryComponents/Resources/Core/Assets/AndesPaletteColors.xcassets/andes-text-color-warning.colorset/Contents.json
+++ b/LibraryComponents/Resources/Core/Assets/AndesPaletteColors.xcassets/andes-text-color-warning.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.200",
+          "green" : "0.467",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}


### PR DESCRIPTION
### Thanks for contributing to Andes UI!
## Description
Se añaden colores en .xcassets de estado warning
## Affected component
AndesUI
## RFC Link

## Screenshots / GIFs

## Checks
Are you sure you followed all those steps? If so, repeat after me "I solemnly swear that ...":
   - [ ] I have coded an example inside the Demo App,
   - [x] I have added proper tests,
   - [x] I have modified the Changelog.md file,
   - [ ] I have updated GitHub wiki,
   - [ ] I have the explicit approval of one or more members of the UX Team,
   - [ ] I have checked that this code is ObjC compliant.
   - [ ] I have checked that all the new public enums conform to AndesEnumStringConvertible.
## Change type
This is easy, let us know what this code is about:
   - [ ] This code adds a new component
   - [ ] This code includes improvements to an existent component
   - [ ] This code improves or modifies ONLY the Demo App.
