### PR TITLE
Fix property name and color in colorset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Unpublished
+### 🛠 Bug fixes
+- Fix color name and color in colorset | Authors [joalonspint](https://github.com/joalonsopint)
+
+# 3.22.0
 ### ⚙️ Other
 - Lib & testapp updated config: | Authors [jbrunoAtMeli] (https://github.com/jbrunoAtMeli)
     The following recommended warnings were enabled

--- a/Example/Tests/AndesStyleSheetTests.swift
+++ b/Example/Tests/AndesStyleSheetTests.swift
@@ -61,6 +61,7 @@ class AndesStyleSheetTests: QuickSpec {
         equal = equal && styleSheetOne.bgColorSecondary.isEqual(styleSheetTwo.bgColorSecondary)
 
         equal = equal && styleSheetOne.tetColorLink.isEqual(styleSheetTwo.tetColorLink)
+        equal = equal && styleSheetOne.textColorLink.isEqual(styleSheetTwo.textColorLink)
         equal = equal && styleSheetOne.textColorCaution.isEqual(styleSheetTwo.textColorCaution)
         equal = equal && styleSheetOne.textColorWhite.isEqual(styleSheetTwo.textColorWhite)
         equal = equal && styleSheetOne.textColorPrimary.isEqual(styleSheetTwo.textColorPrimary)
@@ -139,6 +140,8 @@ class AndesStyleSheetWhiteMock: AndesStyleSheet {
 
     var tetColorLink: UIColor = .white
 
+    var textColorLink: UIColor = .white
+
     var textColorWhite: UIColor = .white
 
     var feedbackColorNegative: UIColor = .white
@@ -146,9 +149,9 @@ class AndesStyleSheetWhiteMock: AndesStyleSheet {
     var feedbackColorCaution: UIColor = .white
 
     var feedbackColorPositive: UIColor = .white
-    
+
     var feedbackColorWarning: UIColor = .white
-    
+
     var textColorWarning: UIColor = .white
 
     func titleXS(color: UIColor) -> AndesFontStyle {
@@ -208,9 +211,9 @@ class AndesStyleSheetWhiteMock: AndesStyleSheet {
 
 class AndesStyleSheetBlackMock: AndesStyleSheet {
     var textColorWarning: UIColor = .black
-    
+
     var feedbackColorWarning: UIColor = .black
-    
+
     var bgColorPrimary: UIColor = .black
 
     var bgColorSecondary: UIColor = .black
@@ -252,6 +255,8 @@ class AndesStyleSheetBlackMock: AndesStyleSheet {
     var textColorPositive: UIColor = .black
 
     var tetColorLink: UIColor = .black
+
+    var textColorLink: UIColor = .black
 
     var textColorWhite: UIColor = .black
 

--- a/LibraryComponents/Classes/Core/Stylesheet/AndesColorStrategyiOS10.swift
+++ b/LibraryComponents/Classes/Core/Stylesheet/AndesColorStrategyiOS10.swift
@@ -33,6 +33,7 @@ public class AndesColorStrategyiOS10: AndesColors {
     public var textColorCaution: UIColor = UIColor.Andes.orange500
     public var textColorPositive: UIColor = UIColor.Andes.green500
     public var tetColorLink: UIColor = UIColor.Andes.blueMP500
+    public var textColorLink: UIColor = UIColor.Andes.blueMP500
     public var textColorWhite: UIColor = UIColor.Andes.white
     public var textColorWarning: UIColor = UIColor.Andes.orange500
 

--- a/LibraryComponents/Classes/Core/Stylesheet/AndesColorStrategyiOS11.swift
+++ b/LibraryComponents/Classes/Core/Stylesheet/AndesColorStrategyiOS11.swift
@@ -33,6 +33,7 @@ public class AndesColorStrategyiOS11: AndesColors {
     public var textColorCaution: UIColor = UIColor(named: "andes-text-color-caution", in: AndesBundle.bundle(), compatibleWith: nil)!
     public var textColorPositive: UIColor = UIColor(named: "andes-text-color-positive", in: AndesBundle.bundle(), compatibleWith: nil)!
     public var tetColorLink: UIColor = UIColor(named: "andes-text-color-link", in: AndesBundle.bundle(), compatibleWith: nil)!
+    public var textColorLink: UIColor = UIColor(named: "andes-text-color-link", in: AndesBundle.bundle(), compatibleWith: nil)!
     public var textColorWhite: UIColor = UIColor(named: "andes-text-color-white", in: AndesBundle.bundle(), compatibleWith: nil)!
     public var textColorWarning: UIColor = UIColor(named: "andes-text-color-warning", in: AndesBundle.bundle(), compatibleWith: nil)!
 

--- a/LibraryComponents/Classes/Core/Stylesheet/AndesStyleSheet.swift
+++ b/LibraryComponents/Classes/Core/Stylesheet/AndesStyleSheet.swift
@@ -42,7 +42,7 @@ import Foundation
     var textColorNegative: UIColor { get }
     var textColorCaution: UIColor { get }
     var textColorPositive: UIColor { get }
-    @available(*, deprecated)
+    @available(*, deprecated, renamed: "textColorLink")
     var tetColorLink: UIColor { get }
     var textColorLink: UIColor { get }
     var textColorWhite: UIColor { get }

--- a/LibraryComponents/Classes/Core/Stylesheet/AndesStyleSheet.swift
+++ b/LibraryComponents/Classes/Core/Stylesheet/AndesStyleSheet.swift
@@ -42,7 +42,9 @@ import Foundation
     var textColorNegative: UIColor { get }
     var textColorCaution: UIColor { get }
     var textColorPositive: UIColor { get }
+    @available(*, deprecated)
     var tetColorLink: UIColor { get }
+    var textColorLink: UIColor { get }
     var textColorWhite: UIColor { get }
     var textColorWarning: UIColor { get }
 

--- a/LibraryComponents/Classes/Core/Stylesheet/AndesStyleSheetDefault.swift
+++ b/LibraryComponents/Classes/Core/Stylesheet/AndesStyleSheetDefault.swift
@@ -35,6 +35,7 @@ import Foundation
     public lazy var textColorCaution: UIColor = self.stylesheetStrategy.textColorCaution
     public lazy var textColorPositive: UIColor = self.stylesheetStrategy.textColorPositive
     public lazy var tetColorLink: UIColor = self.stylesheetStrategy.tetColorLink
+    public lazy var textColorLink: UIColor = self.stylesheetStrategy.textColorLink
     public lazy var textColorWhite: UIColor = self.stylesheetStrategy.textColorWhite
     public lazy var textColorWarning: UIColor = self.stylesheetStrategy.textColorWarning
 
@@ -124,7 +125,7 @@ import Foundation
     }
 
     private func validateColorForLink(color: UIColor) {
-        if !color.isEqual(self.stylesheetStrategy.tetColorLink) {
+        if !color.isEqual(self.stylesheetStrategy.textColorLink) {
             fatalError("You must use an allowed color. Please check Andes documentation")
         }
     }

--- a/LibraryComponents/Resources/Core/Assets/AndesPaletteColors.xcassets/andes-text-color-link.colorset/Contents.json
+++ b/LibraryComponents/Resources/Core/Assets/AndesPaletteColors.xcassets/andes-text-color-link.colorset/Contents.json
@@ -1,20 +1,20 @@
 {
-  "info" : {
-    "version" : 1,
-    "author" : "xcode"
-  },
   "colors" : [
     {
-      "idiom" : "universal",
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "red" : "0.000",
           "alpha" : "1.000",
-          "blue" : "0.400",
-          "green" : "0.278"
+          "blue" : "0xE3",
+          "green" : "0x9E",
+          "red" : "0x00"
         }
-      }
+      },
+      "idiom" : "universal"
     }
-  ]
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
 }


### PR DESCRIPTION
### Thanks for contributing to Andes UI!
## Description
Se depreca una propiedad por qué el nombre está mal escrito, se hace de esta forma para no afectar integraciones de otros equipos.
 Se cambia color en el colorset que estaba mal.
## Affected component
Color de los links en los componentes
## Variant component

## RFC Link

## Screenshots / GIFs

## Checks
Are you sure you followed all those steps? If so, repeat after me "I solemnly swear that ...":
   - [ ] I have coded an example inside the Demo App.
   - [x] I have added proper tests.
   - [x] I have modified the Changelog.md file.
   - [ ] I have updated GitHub wiki.
   - [ ] I have the explicit approval of one or more members of the UX Team.
   - [ ] I have notify Andes team for PR.
   - [ ] I have checked that this code is ObjC compliant.
   - [ ] I have checked that all the new public enums conform to AndesEnumStringConvertible.
## Change type
This is easy, let us know what this code is about:
   - [ ] This code adds a new component
   - [x] This code includes improvements to an existent component
   - [ ] This code improves or modifies ONLY the Demo App.
